### PR TITLE
feat: Laufende Session card (v1.3.4)

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -60,6 +60,7 @@
     "settings": "Einstellungen",
     "admin": "Admin",
     "signOut": "Abmelden",
+    "signOutConfirm": "Wirklich abmelden?",
     "build": "Build",
     "copyright": "© trublue {year}"
   },
@@ -183,6 +184,7 @@
     "saveBtn": "Passwort ändern",
     "saving": "Wird gespeichert…",
     "signOut": "Abmelden",
+    "signOutConfirm": "Wirklich abmelden?",
     "language": "Sprache"
   },
   "changelog": {

--- a/messages/de.json
+++ b/messages/de.json
@@ -45,7 +45,11 @@
     "close": "Schliessen",
     "saved": "✓ Gespeichert",
     "exifDate": "EXIF-Datum",
-    "photoUnavailable": "Foto nicht mehr verfügbar"
+    "photoUnavailable": "Foto nicht mehr verfügbar",
+    "selectCamera": "Kamera auswählen",
+    "chooseFile": "Aus Dateien wählen",
+    "captureBtn": "Foto aufnehmen",
+    "webcamNotAvailable": "Kamera nicht verfügbar"
   },
   "nav": {
     "overview": "Übersicht",

--- a/messages/de.json
+++ b/messages/de.json
@@ -91,7 +91,12 @@
     "week": "Woche",
     "month": "Monat",
     "notCaptured": "nicht erfasst",
-    "stillLocked": "noch verschlossen"
+    "stillLocked": "noch verschlossen",
+    "sessionTitle": "Laufende Session",
+    "sessionSince": "Seit",
+    "sessionLockedUntil": "Gesperrt bis",
+    "sessionKontrolle": "Kontrolle",
+    "sessionOrgasmus": "Orgasmus"
   },
   "newEntry": {
     "title": "Neu erfassen",

--- a/messages/de.json
+++ b/messages/de.json
@@ -49,7 +49,9 @@
     "selectCamera": "Kamera auswählen",
     "chooseFile": "Aus Dateien wählen",
     "captureBtn": "Foto aufnehmen",
-    "webcamNotAvailable": "Kamera nicht verfügbar"
+    "webcamNotAvailable": "Kamera nicht verfügbar",
+    "webcam": "Webcam",
+    "signOutConfirm": "Wirklich abmelden?"
   },
   "nav": {
     "overview": "Übersicht",

--- a/messages/en.json
+++ b/messages/en.json
@@ -49,7 +49,9 @@
     "selectCamera": "Select camera",
     "chooseFile": "Choose from files",
     "captureBtn": "Take photo",
-    "webcamNotAvailable": "Camera not available"
+    "webcamNotAvailable": "Camera not available",
+    "webcam": "Webcam",
+    "signOutConfirm": "Really sign out?"
   },
   "nav": {
     "overview": "Overview",

--- a/messages/en.json
+++ b/messages/en.json
@@ -45,7 +45,11 @@
     "close": "Close",
     "saved": "✓ Saved",
     "exifDate": "EXIF date",
-    "photoUnavailable": "Photo no longer available"
+    "photoUnavailable": "Photo no longer available",
+    "selectCamera": "Select camera",
+    "chooseFile": "Choose from files",
+    "captureBtn": "Take photo",
+    "webcamNotAvailable": "Camera not available"
   },
   "nav": {
     "overview": "Overview",

--- a/messages/en.json
+++ b/messages/en.json
@@ -91,7 +91,12 @@
     "week": "Week",
     "month": "Month",
     "notCaptured": "Not captured",
-    "stillLocked": "still locked"
+    "stillLocked": "still locked",
+    "sessionTitle": "Active Session",
+    "sessionSince": "Since",
+    "sessionLockedUntil": "Locked until",
+    "sessionKontrolle": "Inspection",
+    "sessionOrgasmus": "Orgasm"
   },
   "newEntry": {
     "title": "New entry",

--- a/messages/en.json
+++ b/messages/en.json
@@ -60,6 +60,7 @@
     "settings": "Settings",
     "admin": "Admin",
     "signOut": "Sign out",
+    "signOutConfirm": "Really sign out?",
     "build": "Build",
     "copyright": "© trublue {year}"
   },
@@ -183,6 +184,7 @@
     "saveBtn": "Change password",
     "saving": "Saving…",
     "signOut": "Sign out",
+    "signOutConfirm": "Really sign out?",
     "language": "Language"
   },
   "changelog": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kg-app",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kg-app",
-  "version": "1.3.4",
+  "version": "1.4.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/admin/users/[id]/page.tsx
+++ b/src/app/admin/users/[id]/page.tsx
@@ -1,12 +1,13 @@
 import { auth } from "@/lib/auth";
 import { logAccess } from "@/lib/serverLog";
 import { prisma } from "@/lib/prisma";
-import { formatDuration, formatDateTime, formatHours, toDateLocale } from "@/lib/utils";
+import { formatDuration, formatDateTime, formatHours, toDateLocale, wearingHoursInRange } from "@/lib/utils";
 import { KONTROLLE_PILLS } from "@/lib/kontrollePills";
 import ChangePasswordButton from "@/app/admin/ChangePasswordButton";
 import ChangeEmailButton from "@/app/admin/ChangeEmailButton";
 import PairRow from "@/app/dashboard/PairRow";
 import StatusBanner from "@/app/dashboard/StatusBanner";
+import LaufendeSessionCard from "@/app/dashboard/LaufendeSessionCard";
 import KontrolleBanner from "@/app/components/KontrolleBanner";
 import ImageViewer from "@/app/components/ImageViewer";
 import EntryActions from "@/app/dashboard/EntryActions";
@@ -92,12 +93,15 @@ export default async function AdminUserOverview({ params }: { params: Promise<{ 
 
   logAccess(session?.user.name ?? "?", `/admin/users/${user.username}`);
   const now = new Date();
-  const [entries, alleAnforderungen, activeVorgabe] = await Promise.all([
+  const [entries, alleAnforderungen, activeVorgabe, activeSperrzeit] = await Promise.all([
     prisma.entry.findMany({ where: { userId: id }, orderBy: { startTime: "desc" } }),
     prisma.kontrollAnforderung.findMany({ where: { userId: id }, orderBy: { createdAt: "desc" } }),
     prisma.trainingVorgabe.findFirst({
       where: { userId: id, gueltigAb: { lte: now }, OR: [{ gueltigBis: null }, { gueltigBis: { gte: now } }] },
       orderBy: { gueltigAb: "desc" },
+    }),
+    prisma.verschlussAnforderung.findFirst({
+      where: { userId: id, art: "SPERRZEIT", withdrawnAt: null, endetAt: { gt: now } },
     }),
   ]);
 
@@ -172,6 +176,48 @@ export default async function AdminUserOverview({ params }: { params: Promise<{ 
     return days > 0 ? `${days}T ${hours}h` : `${hours}h`;
   })();
 
+  // ── Laufende Session ──
+  const activePair = pairs.find((p) => p.active) ?? null;
+
+  const sessionEvents: import("@/app/dashboard/LaufendeSessionCard").SessionEvent[] = activePair
+    ? [
+        {
+          type: "verschluss" as const,
+          time: activePair.verschluss.startTime,
+          imageUrl: activePair.verschluss.imageUrl,
+          note: activePair.verschluss.note,
+        },
+        ...activePair.kontrollen
+          .filter((k) => ["fulfilled", "ai", "manual"].includes(k.status))
+          .map((k) => ({
+            type: "kontrolle" as const,
+            time: k.time,
+            imageUrl: k.imageUrl,
+            note: null,
+            kontrolleCode: k.code,
+          })),
+        ...orgasmusEntries
+          .filter((e) => e.startTime >= activePair.verschluss.startTime)
+          .map((e) => ({
+            type: "orgasmus" as const,
+            time: e.startTime,
+            imageUrl: e.imageUrl,
+            note: e.note,
+            orgasmusArt: e.orgasmusArt,
+          })),
+      ].sort((a, b) => a.time.getTime() - b.time.getTime())
+    : [];
+
+  const nowMidnight = new Date(now);
+  nowMidnight.setHours(0, 0, 0, 0);
+  const weekStart = new Date(now);
+  weekStart.setDate(now.getDate() - ((now.getDay() + 6) % 7));
+  weekStart.setHours(0, 0, 0, 0);
+  const monthStart = new Date(now.getFullYear(), now.getMonth(), 1);
+  const tagH = activePair ? wearingHoursInRange(entries, nowMidnight, now) : 0;
+  const wocheH = activePair ? wearingHoursInRange(entries, weekStart, now) : 0;
+  const monatH = activePair ? wearingHoursInRange(entries, monthStart, now) : 0;
+
   return (
     <main className="w-full max-w-5xl px-6 py-8 flex flex-col gap-6">
       <UserNav userId={id} username={user.username} current="uebersicht" />
@@ -239,8 +285,22 @@ export default async function AdminUserOverview({ params }: { params: Promise<{ 
         </div>
       </div>
 
+      {/* ── Laufende Session ── */}
+      {activePair && (
+        <LaufendeSessionCard
+          sessionStart={activePair.verschluss.startTime}
+          now={now}
+          events={sessionEvents}
+          sperrzeitEndetAt={activeSperrzeit?.endetAt ?? null}
+          activeVorgabe={activeVorgabe}
+          tagH={tagH}
+          wocheH={wocheH}
+          monatH={monatH}
+        />
+      )}
+
       {/* ── Trainingsvorgabe ── */}
-      {activeVorgabe && (
+      {activeVorgabe && !activePair && (
         <div className="bg-white rounded-2xl border border-gray-100 px-5 py-4">
           <p className="text-xs font-semibold uppercase tracking-wider text-gray-400 mb-3">{ts("trainingGoals")}</p>
           <div className="flex items-start gap-3">

--- a/src/app/components/DesktopSidebar.tsx
+++ b/src/app/components/DesktopSidebar.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { LayoutDashboard, BarChart2, Plus, Settings, ShieldCheck, LogOut } from "lucide-react";
 import { useTranslations } from "next-intl";
+import { signOut } from "next-auth/react";
 
 interface Props {
   isAdmin?: boolean;
@@ -54,10 +55,13 @@ export default function DesktopSidebar({ isAdmin, version, buildDate }: Props) {
 
       {/* Footer info */}
       <div className="px-3 py-4 border-t border-gray-100 flex-shrink-0 flex flex-col gap-3">
-        <a href="/api/auth/signout" className="flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium text-gray-500 hover:bg-gray-50 hover:text-gray-800 transition-colors">
+        <button
+          onClick={() => { if (window.confirm(t("signOutConfirm"))) signOut({ callbackUrl: "/login" }); }}
+          className="flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium text-gray-500 hover:bg-gray-50 hover:text-gray-800 transition-colors w-full text-left"
+        >
           <LogOut size={18} strokeWidth={1.75} />
           {t("signOut")}
-        </a>
+        </button>
         <div className="px-2 flex flex-col gap-0.5">
           <a href="https://fetlife.com/trublue_2" target="_blank" rel="noopener noreferrer" className="text-xs text-gray-300 hover:text-gray-400 transition">© trublue {new Date().getFullYear()}</a>
           <span className="text-xs text-gray-300">

--- a/src/app/components/PhotoCapture.tsx
+++ b/src/app/components/PhotoCapture.tsx
@@ -4,6 +4,14 @@ import { useRef, useState, useEffect, useCallback } from "react";
 import { Camera, X, FolderOpen, Loader2 } from "lucide-react";
 import { useTranslations } from "next-intl";
 
+function useIsMobile() {
+  const [isMobile, setIsMobile] = useState(true); // default true = safe for SSR
+  useEffect(() => {
+    setIsMobile(window.matchMedia("(pointer: coarse)").matches);
+  }, []);
+  return isMobile;
+}
+
 interface VideoDevice {
   deviceId: string;
   label: string;
@@ -20,6 +28,7 @@ interface Props {
 
 export default function PhotoCapture({ onFile, uploading, variant = "emerald", compact = false }: Props) {
   const t = useTranslations("common");
+  const isMobile = useIsMobile();
   const fileRef = useRef<HTMLInputElement>(null);
   const videoRef = useRef<HTMLVideoElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -118,10 +127,41 @@ export default function PhotoCapture({ onFile, uploading, variant = "emerald", c
 
   return (
     <>
-      <input ref={fileRef} type="file" accept="image/*" onChange={handleFileChange} className="hidden" />
+      {/* Mobile: single file input with camera capture */}
+      <input
+        ref={fileRef}
+        type="file"
+        accept="image/*"
+        {...(isMobile ? { capture: "environment" } : {})}
+        onChange={handleFileChange}
+        className="hidden"
+      />
 
-      {compact ? (
-        /* ── Compact mode: small inline buttons for "replace" state ── */
+      {isMobile ? (
+        /* ── Mobile: single button, opens camera directly ── */
+        compact ? (
+          <button
+            type="button"
+            onClick={() => fileRef.current?.click()}
+            disabled={uploading}
+            className="text-xs text-gray-500 border border-gray-200 rounded-lg px-3 py-2 hover:bg-gray-50 disabled:opacity-50 transition flex items-center gap-1.5"
+          >
+            {uploading ? <Loader2 size={12} className="animate-spin" /> : <Camera size={12} />}
+            {uploading ? t("loading") : t("replacePhoto")}
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={() => fileRef.current?.click()}
+            disabled={uploading}
+            className={`w-full flex flex-col items-center gap-2 border-2 border-dashed rounded-xl py-8 disabled:opacity-50 transition ${accent.border}`}
+          >
+            {uploading ? <Loader2 size={28} className="animate-spin" /> : <Camera size={28} className={accent.icon} />}
+            <span className={`text-sm font-medium ${accent.text}`}>{uploading ? t("uploading") : t("takePhoto")}</span>
+          </button>
+        )
+      ) : compact ? (
+        /* ── Desktop compact: two small inline buttons ── */
         <div className="flex gap-2">
           <button
             type="button"
@@ -143,7 +183,7 @@ export default function PhotoCapture({ onFile, uploading, variant = "emerald", c
           </button>
         </div>
       ) : (
-        /* ── Default mode: two side-by-side big buttons ── */
+        /* ── Desktop default: two side-by-side big buttons ── */
         <div className="grid grid-cols-2 gap-3">
           <button
             type="button"

--- a/src/app/components/PhotoCapture.tsx
+++ b/src/app/components/PhotoCapture.tsx
@@ -1,0 +1,239 @@
+"use client";
+
+import { useRef, useState, useEffect, useCallback } from "react";
+import { Camera, X, SwitchCamera, FolderOpen, Loader2 } from "lucide-react";
+import { useTranslations } from "next-intl";
+
+interface VideoDevice {
+  deviceId: string;
+  label: string;
+}
+
+interface Props {
+  onFile: (file: File) => void;
+  uploading: boolean;
+  /** "emerald" for Verschluss, "orange" for Pruefung */
+  variant?: "emerald" | "orange";
+  /** If provided, renders children as trigger instead of the default dashed button */
+  children?: React.ReactNode;
+}
+
+export default function PhotoCapture({ onFile, uploading, variant = "emerald", children }: Props) {
+  const t = useTranslations("common");
+  const fileRef = useRef<HTMLInputElement>(null);
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+
+  const [modalOpen, setModalOpen] = useState(false);
+  const [devices, setDevices] = useState<VideoDevice[]>([]);
+  const [selectedDeviceId, setSelectedDeviceId] = useState<string>("");
+  const [capturing, setCapturing] = useState(false);
+  const [camError, setCamError] = useState<string | null>(null);
+
+  const accentBorder = variant === "orange" ? "border-orange-200 hover:border-orange-300 hover:bg-orange-50 text-orange-400" : "border-gray-200 hover:border-gray-300 hover:bg-gray-50 text-gray-400";
+
+  const stopStream = useCallback(() => {
+    streamRef.current?.getTracks().forEach((t) => t.stop());
+    streamRef.current = null;
+  }, []);
+
+  const startStream = useCallback(async (deviceId?: string) => {
+    stopStream();
+    setCamError(null);
+    try {
+      const constraints: MediaStreamConstraints = {
+        video: deviceId ? { deviceId: { exact: deviceId } } : { facingMode: "environment" },
+      };
+      const stream = await navigator.mediaDevices.getUserMedia(constraints);
+      streamRef.current = stream;
+      if (videoRef.current) {
+        videoRef.current.srcObject = stream;
+      }
+
+      // After first permission grant, enumerate labeled devices
+      const all = await navigator.mediaDevices.enumerateDevices();
+      const videoDevices = all
+        .filter((d) => d.kind === "videoinput")
+        .map((d, i) => ({ deviceId: d.deviceId, label: d.label || `Kamera ${i + 1}` }));
+      setDevices(videoDevices);
+      if (!deviceId && videoDevices.length > 0) {
+        setSelectedDeviceId(videoDevices[0].deviceId);
+      }
+    } catch {
+      setCamError(t("webcamNotAvailable"));
+    }
+  }, [stopStream, t]);
+
+  async function openModal() {
+    if (!navigator.mediaDevices?.getUserMedia) {
+      fileRef.current?.click();
+      return;
+    }
+    setModalOpen(true);
+  }
+
+  useEffect(() => {
+    if (modalOpen) {
+      startStream(selectedDeviceId || undefined);
+    } else {
+      stopStream();
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [modalOpen]);
+
+  async function handleDeviceChange(deviceId: string) {
+    setSelectedDeviceId(deviceId);
+    await startStream(deviceId);
+  }
+
+  function capturePhoto() {
+    const video = videoRef.current;
+    const canvas = canvasRef.current;
+    if (!video || !canvas) return;
+    setCapturing(true);
+
+    canvas.width = video.videoWidth;
+    canvas.height = video.videoHeight;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    ctx.drawImage(video, 0, 0);
+
+    canvas.toBlob(
+      (blob) => {
+        setCapturing(false);
+        if (!blob) return;
+        const file = new File([blob], `webcam-${Date.now()}.jpg`, { type: "image/jpeg" });
+        closeModal();
+        onFile(file);
+      },
+      "image/jpeg",
+      0.92
+    );
+  }
+
+  function closeModal() {
+    setModalOpen(false);
+    stopStream();
+    setDevices([]);
+    setSelectedDeviceId("");
+    setCamError(null);
+  }
+
+  function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (file) {
+      if (modalOpen) closeModal();
+      onFile(file);
+    }
+    e.target.value = "";
+  }
+
+  return (
+    <>
+      {/* Hidden file input — no capture attr so desktop shows file picker */}
+      <input
+        ref={fileRef}
+        type="file"
+        accept="image/*"
+        onChange={handleFileChange}
+        className="hidden"
+      />
+
+      {/* Trigger */}
+      {children ? (
+        <span onClick={openModal} style={{ cursor: "pointer" }}>{children}</span>
+      ) : (
+        <button
+          type="button"
+          onClick={openModal}
+          disabled={uploading}
+          className={`w-full flex flex-col items-center gap-2 border-2 border-dashed rounded-xl py-8 disabled:opacity-50 transition ${accentBorder}`}
+        >
+          {uploading ? <Loader2 size={28} className="animate-spin" /> : <Camera size={28} />}
+          <span className="text-sm font-medium">
+            {uploading ? t("uploading") : t("takePhoto")}
+          </span>
+        </button>
+      )}
+
+      {/* Webcam modal */}
+      {modalOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 px-4">
+          <div className="bg-white rounded-2xl w-full max-w-lg overflow-hidden shadow-2xl">
+            {/* Header */}
+            <div className="flex items-center justify-between px-4 py-3 border-b border-gray-100">
+              {devices.length > 1 ? (
+                <select
+                  value={selectedDeviceId}
+                  onChange={(e) => handleDeviceChange(e.target.value)}
+                  className="text-sm text-gray-700 bg-gray-50 border border-gray-200 rounded-lg px-3 py-1.5 focus:outline-none"
+                >
+                  {devices.map((d) => (
+                    <option key={d.deviceId} value={d.deviceId}>
+                      {d.label}
+                    </option>
+                  ))}
+                </select>
+              ) : (
+                <span className="text-sm font-medium text-gray-700 flex items-center gap-1.5">
+                  <SwitchCamera size={14} className="text-gray-400" />
+                  {t("selectCamera")}
+                </span>
+              )}
+              <button
+                type="button"
+                onClick={closeModal}
+                className="text-gray-400 hover:text-gray-600 transition p-1"
+              >
+                <X size={20} />
+              </button>
+            </div>
+
+            {/* Video preview */}
+            <div className="relative bg-black aspect-[4/3] w-full">
+              {camError ? (
+                <div className="absolute inset-0 flex flex-col items-center justify-center text-white gap-2">
+                  <Camera size={32} className="opacity-40" />
+                  <p className="text-sm opacity-60">{camError}</p>
+                </div>
+              ) : (
+                <video
+                  ref={videoRef}
+                  autoPlay
+                  playsInline
+                  muted
+                  className="w-full h-full object-cover"
+                />
+              )}
+            </div>
+
+            {/* Canvas (hidden, used for capture) */}
+            <canvas ref={canvasRef} className="hidden" />
+
+            {/* Actions */}
+            <div className="flex gap-3 p-4">
+              <button
+                type="button"
+                onClick={() => fileRef.current?.click()}
+                className="flex items-center gap-1.5 text-sm text-gray-500 border border-gray-200 rounded-xl px-4 py-2.5 hover:bg-gray-50 transition"
+              >
+                <FolderOpen size={15} />
+                {t("chooseFile")}
+              </button>
+              <button
+                type="button"
+                onClick={capturePhoto}
+                disabled={!!camError || capturing}
+                className="flex-1 flex items-center justify-center gap-2 bg-gray-900 text-white font-semibold rounded-xl py-2.5 hover:bg-gray-700 disabled:opacity-40 transition"
+              >
+                {capturing ? <Loader2 size={16} className="animate-spin" /> : <Camera size={16} />}
+                {t("captureBtn")}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/app/components/PhotoCapture.tsx
+++ b/src/app/components/PhotoCapture.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRef, useState, useEffect, useCallback } from "react";
-import { Camera, X, SwitchCamera, FolderOpen, Loader2 } from "lucide-react";
+import { Camera, X, FolderOpen, Loader2 } from "lucide-react";
 import { useTranslations } from "next-intl";
 
 interface VideoDevice {
@@ -14,11 +14,11 @@ interface Props {
   uploading: boolean;
   /** "emerald" for Verschluss, "orange" for Pruefung */
   variant?: "emerald" | "orange";
-  /** If provided, renders children as trigger instead of the default dashed button */
-  children?: React.ReactNode;
+  /** compact = small inline buttons for "replace photo" state */
+  compact?: boolean;
 }
 
-export default function PhotoCapture({ onFile, uploading, variant = "emerald", children }: Props) {
+export default function PhotoCapture({ onFile, uploading, variant = "emerald", compact = false }: Props) {
   const t = useTranslations("common");
   const fileRef = useRef<HTMLInputElement>(null);
   const videoRef = useRef<HTMLVideoElement>(null);
@@ -31,7 +31,9 @@ export default function PhotoCapture({ onFile, uploading, variant = "emerald", c
   const [capturing, setCapturing] = useState(false);
   const [camError, setCamError] = useState<string | null>(null);
 
-  const accentBorder = variant === "orange" ? "border-orange-200 hover:border-orange-300 hover:bg-orange-50 text-orange-400" : "border-gray-200 hover:border-gray-300 hover:bg-gray-50 text-gray-400";
+  const accent = variant === "orange"
+    ? { border: "border-orange-200 hover:border-orange-300 hover:bg-orange-50", icon: "text-orange-400", text: "text-orange-400" }
+    : { border: "border-gray-200 hover:border-gray-300 hover:bg-gray-50", icon: "text-gray-400", text: "text-gray-400" };
 
   const stopStream = useCallback(() => {
     streamRef.current?.getTracks().forEach((t) => t.stop());
@@ -43,15 +45,13 @@ export default function PhotoCapture({ onFile, uploading, variant = "emerald", c
     setCamError(null);
     try {
       const constraints: MediaStreamConstraints = {
-        video: deviceId ? { deviceId: { exact: deviceId } } : { facingMode: "environment" },
+        video: deviceId ? { deviceId: { exact: deviceId } } : true,
       };
       const stream = await navigator.mediaDevices.getUserMedia(constraints);
       streamRef.current = stream;
       if (videoRef.current) {
         videoRef.current.srcObject = stream;
       }
-
-      // After first permission grant, enumerate labeled devices
       const all = await navigator.mediaDevices.enumerateDevices();
       const videoDevices = all
         .filter((d) => d.kind === "videoinput")
@@ -65,21 +65,13 @@ export default function PhotoCapture({ onFile, uploading, variant = "emerald", c
     }
   }, [stopStream, t]);
 
-  async function openModal() {
-    if (!navigator.mediaDevices?.getUserMedia) {
-      fileRef.current?.click();
-      return;
-    }
-    setModalOpen(true);
-  }
-
   useEffect(() => {
     if (modalOpen) {
-      startStream(selectedDeviceId || undefined);
+      startStream(undefined);
     } else {
       stopStream();
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [modalOpen]);
 
   async function handleDeviceChange(deviceId: string) {
@@ -92,13 +84,11 @@ export default function PhotoCapture({ onFile, uploading, variant = "emerald", c
     const canvas = canvasRef.current;
     if (!video || !canvas) return;
     setCapturing(true);
-
     canvas.width = video.videoWidth;
     canvas.height = video.videoHeight;
     const ctx = canvas.getContext("2d");
     if (!ctx) return;
     ctx.drawImage(video, 0, 0);
-
     canvas.toBlob(
       (blob) => {
         setCapturing(false);
@@ -122,42 +112,61 @@ export default function PhotoCapture({ onFile, uploading, variant = "emerald", c
 
   function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0];
-    if (file) {
-      if (modalOpen) closeModal();
-      onFile(file);
-    }
+    if (file) onFile(file);
     e.target.value = "";
   }
 
   return (
     <>
-      {/* Hidden file input — no capture attr so desktop shows file picker */}
-      <input
-        ref={fileRef}
-        type="file"
-        accept="image/*"
-        onChange={handleFileChange}
-        className="hidden"
-      />
+      <input ref={fileRef} type="file" accept="image/*" onChange={handleFileChange} className="hidden" />
 
-      {/* Trigger */}
-      {children ? (
-        <span onClick={openModal} style={{ cursor: "pointer" }}>{children}</span>
+      {compact ? (
+        /* ── Compact mode: small inline buttons for "replace" state ── */
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={() => fileRef.current?.click()}
+            disabled={uploading}
+            className="text-xs text-gray-500 border border-gray-200 rounded-lg px-3 py-2 hover:bg-gray-50 disabled:opacity-50 transition flex items-center gap-1.5"
+          >
+            <FolderOpen size={12} />
+            {t("replacePhoto")}
+          </button>
+          <button
+            type="button"
+            onClick={() => setModalOpen(true)}
+            disabled={uploading}
+            className="text-xs text-gray-500 border border-gray-200 rounded-lg px-3 py-2 hover:bg-gray-50 disabled:opacity-50 transition flex items-center gap-1.5"
+          >
+            <Camera size={12} />
+            {t("webcam")}
+          </button>
+        </div>
       ) : (
-        <button
-          type="button"
-          onClick={openModal}
-          disabled={uploading}
-          className={`w-full flex flex-col items-center gap-2 border-2 border-dashed rounded-xl py-8 disabled:opacity-50 transition ${accentBorder}`}
-        >
-          {uploading ? <Loader2 size={28} className="animate-spin" /> : <Camera size={28} />}
-          <span className="text-sm font-medium">
-            {uploading ? t("uploading") : t("takePhoto")}
-          </span>
-        </button>
+        /* ── Default mode: two side-by-side big buttons ── */
+        <div className="grid grid-cols-2 gap-3">
+          <button
+            type="button"
+            onClick={() => fileRef.current?.click()}
+            disabled={uploading}
+            className={`flex flex-col items-center gap-2 border-2 border-dashed rounded-xl py-7 disabled:opacity-50 transition ${accent.border}`}
+          >
+            {uploading ? <Loader2 size={24} className="animate-spin" /> : <FolderOpen size={24} className={accent.icon} />}
+            <span className={`text-xs font-medium ${accent.text}`}>{t("chooseFile")}</span>
+          </button>
+          <button
+            type="button"
+            onClick={() => setModalOpen(true)}
+            disabled={uploading}
+            className={`flex flex-col items-center gap-2 border-2 border-dashed rounded-xl py-7 disabled:opacity-50 transition ${accent.border}`}
+          >
+            <Camera size={24} className={accent.icon} />
+            <span className={`text-xs font-medium ${accent.text}`}>{t("webcam")}</span>
+          </button>
+        </div>
       )}
 
-      {/* Webcam modal */}
+      {/* ── Webcam modal ── */}
       {modalOpen && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 px-4">
           <div className="bg-white rounded-2xl w-full max-w-lg overflow-hidden shadow-2xl">
@@ -170,27 +179,18 @@ export default function PhotoCapture({ onFile, uploading, variant = "emerald", c
                   className="text-sm text-gray-700 bg-gray-50 border border-gray-200 rounded-lg px-3 py-1.5 focus:outline-none"
                 >
                   {devices.map((d) => (
-                    <option key={d.deviceId} value={d.deviceId}>
-                      {d.label}
-                    </option>
+                    <option key={d.deviceId} value={d.deviceId}>{d.label}</option>
                   ))}
                 </select>
               ) : (
-                <span className="text-sm font-medium text-gray-700 flex items-center gap-1.5">
-                  <SwitchCamera size={14} className="text-gray-400" />
-                  {t("selectCamera")}
-                </span>
+                <span className="text-sm font-medium text-gray-700">{t("selectCamera")}</span>
               )}
-              <button
-                type="button"
-                onClick={closeModal}
-                className="text-gray-400 hover:text-gray-600 transition p-1"
-              >
+              <button type="button" onClick={closeModal} className="text-gray-400 hover:text-gray-600 transition p-1">
                 <X size={20} />
               </button>
             </div>
 
-            {/* Video preview */}
+            {/* Video */}
             <div className="relative bg-black aspect-[4/3] w-full">
               {camError ? (
                 <div className="absolute inset-0 flex flex-col items-center justify-center text-white gap-2">
@@ -198,34 +198,19 @@ export default function PhotoCapture({ onFile, uploading, variant = "emerald", c
                   <p className="text-sm opacity-60">{camError}</p>
                 </div>
               ) : (
-                <video
-                  ref={videoRef}
-                  autoPlay
-                  playsInline
-                  muted
-                  className="w-full h-full object-cover"
-                />
+                <video ref={videoRef} autoPlay playsInline muted className="w-full h-full object-cover" />
               )}
             </div>
 
-            {/* Canvas (hidden, used for capture) */}
             <canvas ref={canvasRef} className="hidden" />
 
             {/* Actions */}
-            <div className="flex gap-3 p-4">
-              <button
-                type="button"
-                onClick={() => fileRef.current?.click()}
-                className="flex items-center gap-1.5 text-sm text-gray-500 border border-gray-200 rounded-xl px-4 py-2.5 hover:bg-gray-50 transition"
-              >
-                <FolderOpen size={15} />
-                {t("chooseFile")}
-              </button>
+            <div className="p-4">
               <button
                 type="button"
                 onClick={capturePhoto}
                 disabled={!!camError || capturing}
-                className="flex-1 flex items-center justify-center gap-2 bg-gray-900 text-white font-semibold rounded-xl py-2.5 hover:bg-gray-700 disabled:opacity-40 transition"
+                className="w-full flex items-center justify-center gap-2 bg-gray-900 text-white font-semibold rounded-xl py-3 hover:bg-gray-700 disabled:opacity-40 transition"
               >
                 {capturing ? <Loader2 size={16} className="animate-spin" /> : <Camera size={16} />}
                 {t("captureBtn")}

--- a/src/app/dashboard/LaufendeSessionCard.tsx
+++ b/src/app/dashboard/LaufendeSessionCard.tsx
@@ -1,0 +1,188 @@
+import { Lock, CheckCircle2, Droplets } from "lucide-react";
+import ImageViewer from "@/app/components/ImageViewer";
+import { formatDuration, formatHours } from "@/lib/utils";
+import { getTranslations, getLocale } from "next-intl/server";
+import { toDateLocale } from "@/lib/utils";
+
+export interface SessionEvent {
+  type: "verschluss" | "kontrolle" | "orgasmus";
+  time: Date;
+  imageUrl: string | null;
+  note: string | null;
+  kontrolleCode?: string | null;
+  orgasmusArt?: string | null;
+}
+
+interface Props {
+  sessionStart: Date;
+  now: Date;
+  events: SessionEvent[];
+  sperrzeitEndetAt: Date | null;
+  activeVorgabe: {
+    minProTagH: number | null;
+    minProWocheH: number | null;
+    minProMonatH: number | null;
+  } | null;
+  tagH: number;
+  wocheH: number;
+  monatH: number;
+}
+
+function ProgressBar({ actual, target, label }: { actual: number; target: number; label: string }) {
+  const pct = Math.min(100, Math.round((actual / target) * 100));
+  const color = pct >= 100 ? "bg-emerald-500" : pct >= 70 ? "bg-indigo-500" : "bg-indigo-400";
+  return (
+    <div className="flex items-center gap-3">
+      <span className="text-xs text-gray-500 w-12 shrink-0">{label}</span>
+      <div className="flex-1 bg-gray-100 rounded-full h-2 overflow-hidden">
+        <div className={`h-2 rounded-full transition-all ${color}`} style={{ width: `${pct}%` }} />
+      </div>
+      <span className="text-xs text-gray-500 w-16 text-right shrink-0">{actual.toFixed(1)}h / {target}h</span>
+      <span className="text-xs font-semibold text-gray-700 w-9 text-right shrink-0">{pct}%</span>
+    </div>
+  );
+}
+
+export default async function LaufendeSessionCard({
+  sessionStart,
+  now,
+  events,
+  sperrzeitEndetAt,
+  activeVorgabe,
+  tagH,
+  wocheH,
+  monatH,
+}: Props) {
+  const t = await getTranslations("dashboard");
+  const dl = toDateLocale(await getLocale());
+
+  const duration = formatDuration(sessionStart, now, dl);
+
+  const sessionStartStr = sessionStart.toLocaleString(dl, {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+
+  const sperrzeitStr = sperrzeitEndetAt
+    ? sperrzeitEndetAt.toLocaleString(dl, {
+        day: "2-digit",
+        month: "2-digit",
+        year: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+      })
+    : null;
+
+  const hasVorgabe =
+    activeVorgabe &&
+    (activeVorgabe.minProTagH != null ||
+      activeVorgabe.minProWocheH != null ||
+      activeVorgabe.minProMonatH != null);
+
+  return (
+    <div className="bg-white rounded-2xl border border-indigo-100 overflow-hidden">
+      {/* Header */}
+      <div className="px-5 py-4 bg-indigo-50/60 border-b border-indigo-100">
+        <div className="flex items-center justify-between gap-2 flex-wrap">
+          <p className="text-xs font-semibold uppercase tracking-wider text-indigo-500 flex items-center gap-1.5">
+            <Lock size={11} />
+            {t("sessionTitle")}
+          </p>
+          <span className="text-xs font-mono text-indigo-600 bg-indigo-100 px-2 py-0.5 rounded-full">
+            ⏱ {duration}
+          </span>
+        </div>
+        <p className="text-xs text-gray-500 mt-1">
+          {t("sessionSince")} {sessionStartStr}
+        </p>
+        {sperrzeitStr && (
+          <p className="text-xs text-rose-600 font-medium mt-1 flex items-center gap-1">
+            <Lock size={10} />
+            {t("sessionLockedUntil")} {sperrzeitStr}
+          </p>
+        )}
+      </div>
+
+      {/* Timeline */}
+      <div className="divide-y divide-gray-50">
+        {events.map((ev, i) => {
+          const timeStr = ev.time.toLocaleTimeString(dl, { hour: "2-digit", minute: "2-digit" });
+          return (
+            <div key={i} className="px-5 py-3 flex items-start gap-3">
+              {/* Thumbnail */}
+              <div className="w-10 h-10 shrink-0 flex items-center justify-center">
+                {ev.imageUrl ? (
+                  <ImageViewer
+                    src={ev.imageUrl}
+                    alt=""
+                    width={40}
+                    height={40}
+                    className="w-10 h-10 rounded-xl object-cover"
+                  />
+                ) : (
+                  <div className="w-10 h-10 rounded-xl bg-gray-50 flex items-center justify-center">
+                    {ev.type === "verschluss" && <Lock size={16} className="text-indigo-400" />}
+                    {ev.type === "kontrolle" && <CheckCircle2 size={16} className="text-emerald-400" />}
+                    {ev.type === "orgasmus" && <Droplets size={16} className="text-rose-400" />}
+                  </div>
+                )}
+              </div>
+
+              {/* Content */}
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2 flex-wrap">
+                  <span className="text-xs font-mono text-gray-400">{timeStr}</span>
+                  {ev.type === "verschluss" && (
+                    <span className="text-sm font-medium text-indigo-700">{t("lock")}</span>
+                  )}
+                  {ev.type === "kontrolle" && (
+                    <>
+                      <span className="text-sm font-medium text-emerald-700">{t("sessionKontrolle")}</span>
+                      {ev.kontrolleCode && (
+                        <span className="font-mono font-bold text-orange-500 text-xs">{ev.kontrolleCode}</span>
+                      )}
+                    </>
+                  )}
+                  {ev.type === "orgasmus" && (
+                    <>
+                      <span className="text-sm font-medium text-rose-600">{t("sessionOrgasmus")}</span>
+                      {ev.orgasmusArt && (
+                        <span className="text-xs text-rose-400">{ev.orgasmusArt}</span>
+                      )}
+                    </>
+                  )}
+                </div>
+                {ev.note && (
+                  <p className="text-xs text-gray-400 italic mt-0.5 truncate">„{ev.note}"</p>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Trainingsvorgaben */}
+      {hasVorgabe && (
+        <div className="px-5 py-4 border-t border-gray-100">
+          <p className="text-xs font-semibold uppercase tracking-wider text-gray-400 mb-3">
+            {t("trainingGoals")}
+          </p>
+          <div className="flex flex-col gap-2">
+            {activeVorgabe.minProTagH != null && (
+              <ProgressBar actual={tagH} target={activeVorgabe.minProTagH} label={t("day")} />
+            )}
+            {activeVorgabe.minProWocheH != null && (
+              <ProgressBar actual={wocheH} target={activeVorgabe.minProWocheH} label={t("week")} />
+            )}
+            {activeVorgabe.minProMonatH != null && (
+              <ProgressBar actual={monatH} target={activeVorgabe.minProMonatH} label={t("month")} />
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/dashboard/PruefungForm.tsx
+++ b/src/app/dashboard/PruefungForm.tsx
@@ -164,12 +164,7 @@ export default function PruefungForm({ initial, initialCode, initialKommentar }:
             <div className="flex flex-col gap-2 flex-1 pt-1">
               {imageExifTime && <p className="text-xs text-gray-400">EXIF: {new Date(imageExifTime).toLocaleString(dl)}</p>}
               {exifWarning && !uploading && <p className="text-xs text-amber-600 font-medium">⚠ {exifWarning}</p>}
-              <PhotoCapture onFile={handleFile} uploading={uploading} variant="orange">
-                <button type="button" disabled={uploading}
-                  className="text-xs text-gray-500 border border-gray-200 rounded-lg px-3 py-2 hover:bg-gray-50 disabled:opacity-50 transition w-fit">
-                  {uploading ? tCommon("loading") : tCommon("replacePhoto")}
-                </button>
-              </PhotoCapture>
+              <PhotoCapture onFile={handleFile} uploading={uploading} variant="orange" compact />
             </div>
           </div>
         ) : (

--- a/src/app/dashboard/PruefungForm.tsx
+++ b/src/app/dashboard/PruefungForm.tsx
@@ -3,8 +3,8 @@
 import { useRef, useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { toDatetimeLocal, toDateLocale } from "@/lib/utils";
-import { Camera, Loader2 } from "lucide-react";
-import ImageViewer from "@/app/components/ImageViewer";
+import { Loader2 } from "lucide-react";
+import PhotoCapture from "@/app/components/PhotoCapture";
 import { useTranslations, useLocale } from "next-intl";
 
 interface Props {
@@ -28,7 +28,6 @@ export default function PruefungForm({ initial, initialCode, initialKommentar }:
   const tCommon = useTranslations("common");
   const dl = toDateLocale(useLocale());
   const router = useRouter();
-  const fileRef = useRef<HTMLInputElement>(null);
 
   const [startTime, setStartTime] = useState(
     toDatetimeLocal(initial?.startTime) || toDatetimeLocal(new Date())
@@ -76,9 +75,7 @@ export default function PruefungForm({ initial, initialCode, initialKommentar }:
     }
   }, [kontrollCode, imageUrl]);
 
-  async function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
-    const file = e.target.files?.[0];
-    if (!file) return;
+  async function handleFile(file: File) {
     setUploading(true);
     setExifWarning("");
     setImagePreview(URL.createObjectURL(file));
@@ -160,8 +157,6 @@ export default function PruefungForm({ initial, initialCode, initialKommentar }:
         <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">
           {tCommon("photoRequired")} <span className="text-red-500">*</span> <span className="text-gray-400 normal-case font-normal">({tCommon("photoMandatory")})</span>
         </label>
-        <input ref={fileRef} type="file" accept="image/*" capture="environment" onChange={handleFileChange} className="hidden" />
-
         {imagePreview ? (
           <div className="flex items-start gap-4">
             {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -169,18 +164,16 @@ export default function PruefungForm({ initial, initialCode, initialKommentar }:
             <div className="flex flex-col gap-2 flex-1 pt-1">
               {imageExifTime && <p className="text-xs text-gray-400">EXIF: {new Date(imageExifTime).toLocaleString(dl)}</p>}
               {exifWarning && !uploading && <p className="text-xs text-amber-600 font-medium">⚠ {exifWarning}</p>}
-              <button type="button" onClick={() => fileRef.current?.click()} disabled={uploading}
-                className="text-xs text-gray-500 border border-gray-200 rounded-lg px-3 py-2 hover:bg-gray-50 disabled:opacity-50 transition w-fit">
-                {uploading ? tCommon("loading") : tCommon("replacePhoto")}
-              </button>
+              <PhotoCapture onFile={handleFile} uploading={uploading} variant="orange">
+                <button type="button" disabled={uploading}
+                  className="text-xs text-gray-500 border border-gray-200 rounded-lg px-3 py-2 hover:bg-gray-50 disabled:opacity-50 transition w-fit">
+                  {uploading ? tCommon("loading") : tCommon("replacePhoto")}
+                </button>
+              </PhotoCapture>
             </div>
           </div>
         ) : (
-          <button type="button" onClick={() => fileRef.current?.click()} disabled={uploading}
-            className="w-full flex flex-col items-center gap-2 border-2 border-dashed border-orange-200 rounded-xl py-8 text-orange-400 hover:border-orange-300 hover:bg-orange-50 disabled:opacity-50 transition">
-            {uploading ? <Loader2 size={28} className="animate-spin" /> : <Camera size={28} />}
-            <span className="text-sm font-medium">{uploading ? tCommon("uploading") : tCommon("takePhoto")}</span>
-          </button>
+          <PhotoCapture onFile={handleFile} uploading={uploading} variant="orange" />
         )}
       </div>
 

--- a/src/app/dashboard/VerschlussForm.tsx
+++ b/src/app/dashboard/VerschlussForm.tsx
@@ -123,12 +123,7 @@ export default function VerschlussForm({ initial }: Props) {
               {exifWarning && !uploading && (
                 <p className="text-xs text-amber-600 font-medium">⚠ {exifWarning}</p>
               )}
-              <PhotoCapture onFile={handleFile} uploading={uploading} variant="emerald">
-                <button type="button" disabled={uploading}
-                  className="text-xs text-gray-500 border border-gray-200 rounded-lg px-3 py-2 hover:bg-gray-50 disabled:opacity-50 transition w-fit">
-                  {uploading ? t("loading") : t("replacePhoto")}
-                </button>
-              </PhotoCapture>
+              <PhotoCapture onFile={handleFile} uploading={uploading} variant="emerald" compact />
               <button type="button" onClick={() => { setImageUrl(""); setImagePreview(""); setImageExifTime(""); setExifWarning(""); }}
                 className="text-xs text-red-400 hover:text-red-600 w-fit transition">
                 {t("removePhoto")}

--- a/src/app/dashboard/VerschlussForm.tsx
+++ b/src/app/dashboard/VerschlussForm.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { toDatetimeLocal, toDateLocale } from "@/lib/utils";
-import { Camera, Loader2 } from "lucide-react";
 import ImageViewer from "@/app/components/ImageViewer";
+import PhotoCapture from "@/app/components/PhotoCapture";
 import { useTranslations, useLocale } from "next-intl";
 
 interface Props {
@@ -22,8 +22,6 @@ export default function VerschlussForm({ initial }: Props) {
   const tForm = useTranslations("lockForm");
   const dl = toDateLocale(useLocale());
   const router = useRouter();
-  const fileRef = useRef<HTMLInputElement>(null);
-
   const [startTime, setStartTime] = useState(
     toDatetimeLocal(initial?.startTime) || toDatetimeLocal(new Date())
   );
@@ -36,9 +34,7 @@ export default function VerschlussForm({ initial }: Props) {
   const [error, setError] = useState("");
   const [exifWarning, setExifWarning] = useState("");
 
-  async function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
-    const file = e.target.files?.[0];
-    if (!file) return;
+  async function handleFile(file: File) {
     setUploading(true);
     setExifWarning("");
     setImagePreview(URL.createObjectURL(file));
@@ -111,8 +107,6 @@ export default function VerschlussForm({ initial }: Props) {
 
       {/* Foto */}
       <Field label={t("photoOptional")}>
-        <input ref={fileRef} type="file" accept="image/*" capture="environment" onChange={handleFileChange} className="hidden" />
-
         {imagePreview ? (
           <div className="flex items-start gap-4">
             <ImageViewer
@@ -129,26 +123,20 @@ export default function VerschlussForm({ initial }: Props) {
               {exifWarning && !uploading && (
                 <p className="text-xs text-amber-600 font-medium">⚠ {exifWarning}</p>
               )}
-              <button type="button" onClick={() => fileRef.current?.click()} disabled={uploading}
-                className="text-xs text-gray-500 border border-gray-200 rounded-lg px-3 py-2 hover:bg-gray-50 disabled:opacity-50 transition w-fit">
-                {uploading ? t("loading") : t("replacePhoto")}
-              </button>
-              <button type="button" onClick={() => { setImageUrl(""); setImagePreview(""); setImageExifTime(""); setExifWarning(""); if (fileRef.current) fileRef.current.value = ""; }}
+              <PhotoCapture onFile={handleFile} uploading={uploading} variant="emerald">
+                <button type="button" disabled={uploading}
+                  className="text-xs text-gray-500 border border-gray-200 rounded-lg px-3 py-2 hover:bg-gray-50 disabled:opacity-50 transition w-fit">
+                  {uploading ? t("loading") : t("replacePhoto")}
+                </button>
+              </PhotoCapture>
+              <button type="button" onClick={() => { setImageUrl(""); setImagePreview(""); setImageExifTime(""); setExifWarning(""); }}
                 className="text-xs text-red-400 hover:text-red-600 w-fit transition">
                 {t("removePhoto")}
               </button>
             </div>
           </div>
         ) : (
-          <button
-            type="button"
-            onClick={() => fileRef.current?.click()}
-            disabled={uploading}
-            className="w-full flex flex-col items-center gap-2 border-2 border-dashed border-gray-200 rounded-xl py-8 text-gray-400 hover:border-gray-300 hover:bg-gray-50 disabled:opacity-50 transition"
-          >
-            {uploading ? <Loader2 size={28} className="animate-spin" /> : <Camera size={28} />}
-            <span className="text-sm font-medium">{uploading ? t("uploading") : t("takePhoto")}</span>
-          </button>
+          <PhotoCapture onFile={handleFile} uploading={uploading} variant="emerald" />
         )}
       </Field>
 

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,10 +1,11 @@
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
-import { formatDuration, formatDateTime, formatHours } from "@/lib/utils";
+import { formatDuration, formatDateTime, formatHours, wearingHoursInRange } from "@/lib/utils";
 import { KONTROLLE_PILLS } from "@/lib/kontrollePills";
 import EntryActions from "./EntryActions";
 import PairRow from "./PairRow";
 import StatusBanner from "./StatusBanner";
+import LaufendeSessionCard from "./LaufendeSessionCard";
 import { Lock, LockOpen, ClipboardList, Droplets } from "lucide-react";
 import ImageViewer from "@/app/components/ImageViewer";
 import KontrolleBanner from "@/app/components/KontrolleBanner";
@@ -177,6 +178,48 @@ export default async function DashboardPage() {
     .filter((e) => e.type === "ORGASMUS")
     .sort((a, b) => b.startTime.getTime() - a.startTime.getTime());
 
+  // ── Laufende Session ──
+  const activePair = pairs.find((p) => p.active) ?? null;
+
+  const sessionEvents: import("./LaufendeSessionCard").SessionEvent[] = activePair
+    ? [
+        {
+          type: "verschluss" as const,
+          time: activePair.verschluss.startTime,
+          imageUrl: activePair.verschluss.imageUrl,
+          note: activePair.verschluss.note,
+        },
+        ...activePair.kontrollen
+          .filter((k) => ["fulfilled", "ai", "manual"].includes(k.status))
+          .map((k) => ({
+            type: "kontrolle" as const,
+            time: k.time,
+            imageUrl: k.imageUrl,
+            note: null,
+            kontrolleCode: k.code,
+          })),
+        ...orgasmusEntries
+          .filter((e) => e.startTime >= activePair.verschluss.startTime)
+          .map((e) => ({
+            type: "orgasmus" as const,
+            time: e.startTime,
+            imageUrl: e.imageUrl,
+            note: e.note,
+            orgasmusArt: e.orgasmusArt,
+          })),
+      ].sort((a, b) => a.time.getTime() - b.time.getTime())
+    : [];
+
+  const nowMidnight = new Date(now);
+  nowMidnight.setHours(0, 0, 0, 0);
+  const weekStart = new Date(now);
+  weekStart.setDate(now.getDate() - ((now.getDay() + 6) % 7));
+  weekStart.setHours(0, 0, 0, 0);
+  const monthStart = new Date(now.getFullYear(), now.getMonth(), 1);
+  const tagH = activePair ? wearingHoursInRange(entries, nowMidnight, now) : 0;
+  const wocheH = activePair ? wearingHoursInRange(entries, weekStart, now) : 0;
+  const monatH = activePair ? wearingHoursInRange(entries, monthStart, now) : 0;
+
   return (
     <>
       <main className="flex-1 w-full max-w-5xl px-6 py-8 flex flex-col gap-6">
@@ -244,8 +287,22 @@ export default async function DashboardPage() {
           <StatCard label={t("totalDuration")} value={totalFormatted} />
         </div>
 
+        {/* ── Laufende Session ── */}
+        {activePair && (
+          <LaufendeSessionCard
+            sessionStart={activePair.verschluss.startTime}
+            now={now}
+            events={sessionEvents}
+            sperrzeitEndetAt={activeSperrzeit?.endetAt ?? null}
+            activeVorgabe={activeVorgabe}
+            tagH={tagH}
+            wocheH={wocheH}
+            monatH={monatH}
+          />
+        )}
+
         {/* ── Trainingsvorgabe ── */}
-        {activeVorgabe && (
+        {activeVorgabe && !activePair && (
           <div className="bg-white rounded-2xl border border-gray-100 px-5 py-4">
             <p className="text-xs font-semibold uppercase tracking-wider text-gray-400 mb-3">{t("trainingGoals")}</p>
             <div className="flex items-start gap-3">

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -123,7 +123,7 @@ export default function SettingsPage() {
       {/* Mobile: Abmelden */}
       <div className="mt-4">
         <button
-          onClick={() => signOut({ callbackUrl: "/login" })}
+          onClick={() => { if (window.confirm(t("signOutConfirm"))) signOut({ callbackUrl: "/login" }); }}
           className="w-full text-sm font-semibold text-white bg-red-500 hover:bg-red-600 rounded-2xl py-4 active:scale-[0.98] transition-all"
         >
           {t("signOut")}

--- a/src/data/changelog.json
+++ b/src/data/changelog.json
@@ -1,5 +1,23 @@
 [
   {
+    "version": "1.4.0",
+    "date": "2026-03-22",
+    "changes": [
+      {
+        "type": "feat",
+        "text": "Webcam-Auswahl auf Desktop: zwei Buttons (Datei / Webcam) mit Live-Vorschau und Gerätewahl"
+      },
+      {
+        "type": "feat",
+        "text": "Laufende Session: neue Karte zeigt Timeline (Verschluss, Kontrollen, Orgasmen), Sperrdauer und Trainingsvorgaben-Fortschritt"
+      },
+      {
+        "type": "fix",
+        "text": "Logout ohne Bestätigungsseite – einfache JS-Abfrage statt NextAuth-Redirect"
+      }
+    ]
+  },
+  {
     "version": "1.3.4",
     "date": "2026-03-22",
     "changes": [

--- a/src/data/changelog.json
+++ b/src/data/changelog.json
@@ -1,5 +1,15 @@
 [
   {
+    "version": "1.3.4",
+    "date": "2026-03-22",
+    "changes": [
+      {
+        "type": "feat",
+        "text": "Neue Karte «Laufende Session» zeigt alle Ereignisse der aktiven Session (Verschluss, Kontrollen, Orgasmen) mit Timeline, Sperrdauer und Trainingsvorgaben-Fortschritt"
+      }
+    ]
+  },
+  {
     "version": "1.3.3",
     "date": "2026-03-22",
     "changes": [

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -56,6 +56,38 @@ export function formatDateTime(date: Date | string, locale = "de-CH"): string {
   });
 }
 
+/** Berechnet Tragedauer in Stunden innerhalb eines Zeitraums. */
+export function wearingHoursInRange(
+  entries: { type: string; startTime: Date }[],
+  from: Date,
+  to: Date
+): number {
+  const sorted = [...entries]
+    .filter((e) => e.type === "VERSCHLUSS" || e.type === "OEFFNEN")
+    .sort((a, b) => a.startTime.getTime() - b.startTime.getTime());
+
+  let total = 0;
+  let wearStart: Date | null = null;
+
+  for (const e of sorted) {
+    if (e.type === "VERSCHLUSS") {
+      wearStart = e.startTime;
+    } else if (e.type === "OEFFNEN" && wearStart) {
+      const s = Math.max(wearStart.getTime(), from.getTime());
+      const end = Math.min(e.startTime.getTime(), to.getTime());
+      if (end > s) total += end - s;
+      wearStart = null;
+    }
+  }
+  if (wearStart) {
+    const s = Math.max(wearStart.getTime(), from.getTime());
+    const end = to.getTime();
+    if (end > s) total += end - s;
+  }
+
+  return total / (1000 * 60 * 60);
+}
+
 export function toDatetimeLocal(date: Date | string | null | undefined): string {
   if (!date) return "";
   const d = new Date(date);


### PR DESCRIPTION
## Summary

- New **LaufendeSessionCard** component shown on dashboard and admin user view when status is «Verschlossen»
- Displays session timeline: Verschluss → fulfilled Kontrollen → Orgasmen (chronological), with photo thumbnails
- Shows session start time + running duration, and «Gesperrt bis» if a Sperrzeit is active
- Integrates Trainingsvorgaben with per-day/week/month progress bars (actual vs. target hours)
- Standalone Trainingsvorgabe card is hidden when the session card is visible
- Added `wearingHoursInRange()` to `utils.ts` for accurate wearing-hours calculation within a date range
- Added `activeSperrzeit` query to admin user detail page (was missing)
- New i18n keys in `dashboard` namespace: `sessionTitle`, `sessionSince`, `sessionLockedUntil`, `sessionKontrolle`, `sessionOrgasmus`

## Test plan

- [ ] Log in as a locked user → Session card appears after StatCards
- [ ] Fulfilled Kontrolle in active session → shows in timeline with code
- [ ] Orgasmus entry since lock → shows in timeline with art
- [ ] Active Sperrzeit → «Gesperrt bis» line appears in card header
- [ ] Trainingsvorgabe set → progress bars appear at bottom of card
- [ ] Open user (not locked) → no session card, standalone Vorgabe card visible normally
- [ ] Admin: open user detail page of locked user → same session card visible
- [ ] `npm run build` passes without TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)