### PR TITLE
fix: vollständige Zeitzonenkorrektur (CET/CEST)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kg-app",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -10,7 +10,7 @@ import KontrolleBanner from "@/app/components/KontrolleBanner";
 import VerschlussAnforderungButton from "./VerschlussAnforderungButton";
 import WithdrawVerschlussButton from "./WithdrawVerschlussButton";
 import { getTranslations, getLocale } from "next-intl/server";
-import { toDateLocale } from "@/lib/utils";
+import { toDateLocale, APP_TZ } from "@/lib/utils";
 
 async function getUserStats(userId: string) {
   const entries = await prisma.entry.findMany({
@@ -113,6 +113,7 @@ export default async function AdminPage() {
                   year: "numeric",
                   hour: "2-digit",
                   minute: "2-digit",
+                  timeZone: APP_TZ,
                 })
               : null;
 
@@ -194,7 +195,7 @@ export default async function AdminPage() {
                       <span className="text-xs text-indigo-700 font-medium truncate">{t("lockRequested")}</span>
                       {u.stats.offeneAnforderung.endetAt && (
                         <span className="text-xs text-indigo-400 shrink-0">
-                          {tc("to")} {new Date(u.stats.offeneAnforderung.endetAt).toLocaleString(dl, { day: "2-digit", month: "2-digit", hour: "2-digit", minute: "2-digit" })}
+                          {tc("to")} {new Date(u.stats.offeneAnforderung.endetAt).toLocaleString(dl, { day: "2-digit", month: "2-digit", hour: "2-digit", minute: "2-digit", timeZone: APP_TZ })}
                         </span>
                       )}
                     </div>
@@ -208,7 +209,7 @@ export default async function AdminPage() {
                       <span className="text-xs text-rose-700 font-medium">{t("lockedUntil")}</span>
                       {u.stats.activeSperrzeit.endetAt && (
                         <span className="text-xs text-rose-600 font-bold shrink-0">
-                          {new Date(u.stats.activeSperrzeit.endetAt).toLocaleString(dl, { day: "2-digit", month: "2-digit", hour: "2-digit", minute: "2-digit" })}
+                          {new Date(u.stats.activeSperrzeit.endetAt).toLocaleString(dl, { day: "2-digit", month: "2-digit", hour: "2-digit", minute: "2-digit", timeZone: APP_TZ })}
                         </span>
                       )}
                     </div>

--- a/src/app/admin/users/[id]/vorgaben/page.tsx
+++ b/src/app/admin/users/[id]/vorgaben/page.tsx
@@ -5,7 +5,7 @@ import VorgabeForm from "../VorgabeForm";
 import VorgabeRow from "../VorgabeRow";
 import UserNav from "../UserNav";
 import { getLocale, getTranslations } from "next-intl/server";
-import { toDateLocale } from "@/lib/utils";
+import { toDateLocale, APP_TZ } from "@/lib/utils";
 
 function isActive(v: { gueltigAb: Date; gueltigBis: Date | null }): boolean {
   const now = new Date();
@@ -50,7 +50,7 @@ export default async function VorgabenPage({ params }: { params: Promise<{ id: s
                 userId={id}
                 vorgabeId={v.id}
                 active={isActive(v)}
-                dateLabel={`${new Date(v.gueltigAb).toLocaleDateString(dl)}${v.gueltigBis ? ` → ${new Date(v.gueltigBis).toLocaleDateString(dl)}` : ` → ${tc("open")}`}`}
+                dateLabel={`${new Date(v.gueltigAb).toLocaleDateString(dl, { timeZone: APP_TZ })}${v.gueltigBis ? ` → ${new Date(v.gueltigBis).toLocaleDateString(dl, { timeZone: APP_TZ })}` : ` → ${tc("open")}`}`}
                 tagH={v.minProTagH}
                 wocheH={v.minProWocheH}
                 monatH={v.minProMonatH}

--- a/src/app/api/admin/kontrolle/route.ts
+++ b/src/app/api/admin/kontrolle/route.ts
@@ -50,7 +50,7 @@ export async function POST(req: NextRequest) {
   const link = `${baseUrl}/dashboard/new/pruefung?code=${code}${kommentarParam}`;
   const deadlineStr = deadline.toLocaleString("de-CH", {
     day: "2-digit", month: "2-digit", year: "numeric",
-    hour: "2-digit", minute: "2-digit",
+    hour: "2-digit", minute: "2-digit", timeZone: "Europe/Zurich",
   });
 
   await sendMail(

--- a/src/app/api/admin/verschluss-anforderung/route.ts
+++ b/src/app/api/admin/verschluss-anforderung/route.ts
@@ -63,7 +63,7 @@ export async function POST(req: NextRequest) {
     if (art === "ANFORDERUNG" && user.email) {
       const baseUrl = process.env.NEXTAUTH_URL ?? "http://localhost:3000";
       const deadlineHtml = endetAtDate
-        ? `<p><strong>Bitte einschliessen bis:</strong> ${endetAtDate.toLocaleString("de-CH", { day: "2-digit", month: "2-digit", year: "numeric", hour: "2-digit", minute: "2-digit" })}</p>`
+        ? `<p><strong>Bitte einschliessen bis:</strong> ${endetAtDate.toLocaleString("de-CH", { day: "2-digit", month: "2-digit", year: "numeric", hour: "2-digit", minute: "2-digit", timeZone: "Europe/Zurich" })}</p>`
         : "";
       const dauerHtml = dauerH && !endetAt
         ? `<p><strong>Mindestdauer nach Einschliessen:</strong> ${dauerH >= 24 ? `${Math.floor(dauerH / 24)}T ${dauerH % 24 > 0 ? `${dauerH % 24}h` : ""}`.trim() : `${dauerH}h`}</p>`

--- a/src/app/components/StatsMain.tsx
+++ b/src/app/components/StatsMain.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 import { prisma } from "@/lib/prisma";
-import { formatDuration, formatDateTime, formatHours, formatMs, toDateLocale } from "@/lib/utils";
+import { formatDuration, formatDateTime, formatHours, formatMs, toDateLocale, APP_TZ } from "@/lib/utils";
 import { KONTROLLE_PILLS } from "@/lib/kontrollePills";
 import CalendarExpand from "./CalendarExpand";
 import { type CalendarMonthData, type CalendarDayData } from "./CalendarContainer";
@@ -287,7 +287,7 @@ export default async function StatsMain({ userId, heading, backHref, backLabel }
           .sort((a, b) => a.startTime.getTime() - b.startTime.getTime())
           .map((e) => ({
             type: e.type,
-            time: e.startTime.toLocaleTimeString(dl, { hour: "2-digit", minute: "2-digit" }),
+            time: e.startTime.toLocaleTimeString(dl, { hour: "2-digit", minute: "2-digit", timeZone: APP_TZ }),
             note: e.note,
             orgasmusArt: e.orgasmusArt,
           }));
@@ -295,7 +295,7 @@ export default async function StatsMain({ userId, heading, backHref, backLabel }
           minProTagH: vorgabe.minProTagH, minProWocheH: vorgabe.minProWocheH,
           minProMonatH: vorgabe.minProMonatH, notiz: vorgabe.notiz,
         } : null;
-        const dateLabel = new Date(year, month, day).toLocaleDateString(dl, { day: "numeric", month: "long", year: "numeric" });
+        const dateLabel = new Date(year, month, day).toLocaleDateString(dl, { day: "numeric", month: "long", year: "numeric", timeZone: APP_TZ });
         return { day, dateLabel, wearHours: data?.hours ?? 0, hasOrgasm: data?.hasOrgasm ?? false, dailyGoalMet, colorClass, entries: dayEntries, vorgabe: dayVorgabe };
       }));
     }
@@ -441,14 +441,14 @@ export default async function StatsMain({ userId, heading, backHref, backLabel }
                   <span className={`text-xs font-medium border rounded-full px-2 py-0.5 flex-shrink-0 ${cls}`}>{label}</span>
                   {k.code && <span className="font-mono font-bold text-orange-500 text-sm">{k.code}</span>}
                   {k.deadline
-                    ? <span className="text-xs text-gray-400 truncate">{t("deadlineLabel")}: {new Date(k.deadline).toLocaleString(dl, { day: "2-digit", month: "2-digit", year: "numeric", hour: "2-digit", minute: "2-digit" })}</span>
-                    : <span className="text-xs text-gray-400 truncate">{k.time.toLocaleString(dl, { day: "2-digit", month: "2-digit", year: "numeric", hour: "2-digit", minute: "2-digit" })}</span>
+                    ? <span className="text-xs text-gray-400 truncate">{t("deadlineLabel")}: {new Date(k.deadline).toLocaleString(dl, { day: "2-digit", month: "2-digit", year: "numeric", hour: "2-digit", minute: "2-digit", timeZone: APP_TZ })}</span>
+                    : <span className="text-xs text-gray-400 truncate">{k.time.toLocaleString(dl, { day: "2-digit", month: "2-digit", year: "numeric", hour: "2-digit", minute: "2-digit", timeZone: APP_TZ })}</span>
                   }
                   {k.entryTime && k.status !== "rejected" && (
-                    <span className="text-xs text-gray-400 ml-auto flex-shrink-0">{t("fulfilled")}: {new Date(k.entryTime).toLocaleString(dl, { day: "2-digit", month: "2-digit", hour: "2-digit", minute: "2-digit" })}</span>
+                    <span className="text-xs text-gray-400 ml-auto flex-shrink-0">{t("fulfilled")}: {new Date(k.entryTime).toLocaleString(dl, { day: "2-digit", month: "2-digit", hour: "2-digit", minute: "2-digit", timeZone: APP_TZ })}</span>
                   )}
                   {k.status === "rejected" && k.entryTime && (
-                    <span className="text-xs text-red-400 ml-auto flex-shrink-0">{t("rejected")}: {new Date(k.entryTime).toLocaleString(dl, { day: "2-digit", month: "2-digit", hour: "2-digit", minute: "2-digit" })}</span>
+                    <span className="text-xs text-red-400 ml-auto flex-shrink-0">{t("rejected")}: {new Date(k.entryTime).toLocaleString(dl, { day: "2-digit", month: "2-digit", hour: "2-digit", minute: "2-digit", timeZone: APP_TZ })}</span>
                   )}
                 </div>
               );
@@ -477,7 +477,7 @@ export default async function StatsMain({ userId, heading, backHref, backLabel }
             {unerlaubteOeffnungen.map((e) => (
               <div key={e.id} className="px-5 py-3 flex items-center gap-3">
                 <span className="text-sm tabular-nums text-red-800 font-medium shrink-0">
-                  {e.startTime.toLocaleString(dl, { day: "2-digit", month: "2-digit", year: "numeric", hour: "2-digit", minute: "2-digit" })}
+                  {e.startTime.toLocaleString(dl, { day: "2-digit", month: "2-digit", year: "numeric", hour: "2-digit", minute: "2-digit", timeZone: APP_TZ })}
                 </span>
                 {e.note
                   ? <span className="text-sm text-red-600 italic truncate">„{e.note}"</span>

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -10,7 +10,7 @@ export default async function DashboardLayout({ children }: { children: React.Re
   const session = await auth();
   const user = session?.user;
   const buildDate = process.env.BUILD_DATE
-    ? new Date(process.env.BUILD_DATE).toLocaleString("de-CH", { day: "2-digit", month: "2-digit", year: "numeric", hour: "2-digit", minute: "2-digit" })
+    ? new Date(process.env.BUILD_DATE).toLocaleString("de-CH", { day: "2-digit", month: "2-digit", year: "numeric", hour: "2-digit", minute: "2-digit", timeZone: "Europe/Zurich" })
     : "local";
 
   return (

--- a/src/data/changelog.json
+++ b/src/data/changelog.json
@@ -1,5 +1,15 @@
 [
   {
+    "version": "1.5.4",
+    "date": "2026-03-22",
+    "changes": [
+      {
+        "type": "fix",
+        "text": "Zeitzone vollständig korrigiert: alle Zeitanzeigen (Statistiken, Kalender, Kontrollliste, unerlaubte Öffnungen, E-Mails) verwenden jetzt CET/CEST statt UTC"
+      }
+    ]
+  },
+  {
     "version": "1.5.3",
     "date": "2026-03-22",
     "changes": [


### PR DESCRIPTION
## Summary
- `timeZone: APP_TZ` zu allen server-seitigen `toLocaleString/toLocaleDateString/toLocaleTimeString`-Aufrufen hinzugefügt (StatsMain, dashboard/layout, admin/page, vorgaben/page)
- E-Mail-Templates für Kontrolle-Anforderung und Verschluss-Anforderung korrigiert
- Version 1.5.4

## Test plan
- [ ] Zeiten in Statistiken, Kalender, Kontrollliste, unerlaubte Öffnungen zeigen CET/CEST an
- [ ] E-Mails enthalten korrekte Lokalzeit
- [ ] Build fehlerfrei (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)