### PR TITLE
refactor: zentrale Hilfsfunktionen in utils.ts und queries.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kg-app",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -10,7 +10,7 @@ import KontrolleBanner from "@/app/components/KontrolleBanner";
 import VerschlussAnforderungButton from "./VerschlussAnforderungButton";
 import WithdrawVerschlussButton from "./WithdrawVerschlussButton";
 import { getTranslations, getLocale } from "next-intl/server";
-import { toDateLocale, APP_TZ } from "@/lib/utils";
+import { toDateLocale, formatDateTime, APP_TZ } from "@/lib/utils";
 
 async function getUserStats(userId: string) {
   const entries = await prisma.entry.findMany({
@@ -106,16 +106,7 @@ export default async function AdminPage() {
         <div className="grid gap-4 sm:grid-cols-2">
           {usersWithStats.map((u) => {
             const isLocked = u.stats.currentStatus === "VERSCHLUSS";
-            const sinceStr = u.stats.since
-              ? new Date(u.stats.since).toLocaleString(dl, {
-                  day: "2-digit",
-                  month: "2-digit",
-                  year: "numeric",
-                  hour: "2-digit",
-                  minute: "2-digit",
-                  timeZone: APP_TZ,
-                })
-              : null;
+            const sinceStr = u.stats.since ? formatDateTime(u.stats.since, dl) : null;
 
             return (
               <div key={u.id} className="bg-white rounded-2xl border border-gray-100 p-5 flex flex-col gap-4">

--- a/src/app/admin/users/[id]/page.tsx
+++ b/src/app/admin/users/[id]/page.tsx
@@ -1,7 +1,12 @@
 import { auth } from "@/lib/auth";
 import { logAccess } from "@/lib/serverLog";
 import { prisma } from "@/lib/prisma";
-import { formatDuration, formatDateTime, formatHours, toDateLocale, wearingHoursInRange, APP_TZ } from "@/lib/utils";
+import {
+  formatDuration, formatDateTime, formatDate, formatHours, toDateLocale,
+  wearingHoursInRange, buildPairs, photoStatus, mapKontrolleStatus,
+  getMidnightToday, getWeekStart, getMonthStart, KontrolleStatus,
+} from "@/lib/utils";
+import { getActiveVorgabe } from "@/lib/queries";
 import { KONTROLLE_PILLS } from "@/lib/kontrollePills";
 import ChangePasswordButton from "@/app/admin/ChangePasswordButton";
 import ChangeEmailButton from "@/app/admin/ChangeEmailButton";
@@ -35,7 +40,7 @@ type KontrolleItem = {
   code: string | null;
   deadline: Date | null;
   kommentar: string | null;
-  status: "open" | "overdue" | "fulfilled" | "ai" | "manual" | "rejected" | "withdrawn";
+  status: KontrolleStatus;
   entryId: string | null;
 };
 
@@ -45,43 +50,6 @@ type Pair = {
   active: boolean;
   kontrollen: KontrolleItem[];
 };
-
-function buildPairs(entries: Entry[], kontrollen: KontrolleItem[]): Pair[] {
-  const asc = [...entries]
-    .filter((e) => ["VERSCHLUSS", "OEFFNEN"].includes(e.type))
-    .sort((a, b) => a.startTime.getTime() - b.startTime.getTime());
-  const pairs: Pair[] = [];
-  let pending: Entry | null = null;
-  for (const e of asc) {
-    if (e.type === "VERSCHLUSS") {
-      if (pending) pairs.push({ verschluss: pending, oeffnen: null, active: false, kontrollen: [] });
-      pending = e;
-    } else if (e.type === "OEFFNEN" && pending) {
-      pairs.push({ verschluss: pending, oeffnen: e, active: false, kontrollen: [] });
-      pending = null;
-    }
-  }
-  if (pending) pairs.push({ verschluss: pending, oeffnen: null, active: true, kontrollen: [] });
-  for (const k of kontrollen) {
-    // Pick the most-recent (latest verschluss) pair that contains k.time
-    const pair = pairs.reduce<Pair | null>((best, p) => {
-      const start = p.verschluss.startTime.getTime();
-      const end = p.oeffnen ? p.oeffnen.startTime.getTime() : Infinity;
-      if (k.time.getTime() < start || k.time.getTime() > end) return best;
-      if (!best) return p;
-      return p.verschluss.startTime > best.verschluss.startTime ? p : best;
-    }, null);
-    if (pair) pair.kontrollen.push(k);
-  }
-  return pairs.reverse();
-}
-
-function photoStatus(v: Entry): "no-photo" | "exif-mismatch" | "ok" {
-  if (!v.imageUrl) return "no-photo";
-  if (v.imageExifTime && Math.abs(v.imageExifTime.getTime() - v.startTime.getTime()) > 3600000)
-    return "exif-mismatch";
-  return "ok";
-}
 
 export default async function AdminUserOverview({ params }: { params: Promise<{ id: string }> }) {
   const session = await auth();
@@ -100,10 +68,7 @@ export default async function AdminUserOverview({ params }: { params: Promise<{ 
   const [entries, alleAnforderungen, activeVorgabe, activeSperrzeit] = await Promise.all([
     prisma.entry.findMany({ where: { userId: id }, orderBy: { startTime: "desc" } }),
     prisma.kontrollAnforderung.findMany({ where: { userId: id }, orderBy: { createdAt: "desc" }, include: { entry: true } }),
-    prisma.trainingVorgabe.findFirst({
-      where: { userId: id, gueltigAb: { lte: now }, OR: [{ gueltigBis: null }, { gueltigBis: { gte: now } }] },
-      orderBy: { gueltigAb: "desc" },
-    }),
+    getActiveVorgabe(id, now),
     prisma.verschlussAnforderung.findFirst({
       where: { userId: id, art: "SPERRZEIT", withdrawnAt: null, endetAt: { gt: now } },
     }),
@@ -117,13 +82,7 @@ export default async function AdminUserOverview({ params }: { params: Promise<{ 
   const kontrollItems: KontrolleItem[] = [
     ...alleAnforderungen.map(k => {
       const vs = k.entry?.verifikationStatus ?? null;
-      const status: KontrolleItem["status"] =
-        k.withdrawnAt ? "withdrawn" :
-        !k.entryId ? (k.deadline < now ? "overdue" : "open") :
-        vs === "rejected" ? "rejected" :
-        vs === "manual" ? "manual" :
-        vs === "ai" ? "ai" :
-        "fulfilled";
+      const status = mapKontrolleStatus(k, vs, now);
       return {
         id: k.id,
         time: k.entry ? k.entry.startTime : k.createdAt,
@@ -217,12 +176,9 @@ export default async function AdminUserOverview({ params }: { params: Promise<{ 
       ].sort((a, b) => a.time.getTime() - b.time.getTime())
     : [];
 
-  const nowMidnight = new Date(now);
-  nowMidnight.setHours(0, 0, 0, 0);
-  const weekStart = new Date(now);
-  weekStart.setDate(now.getDate() - ((now.getDay() + 6) % 7));
-  weekStart.setHours(0, 0, 0, 0);
-  const monthStart = new Date(now.getFullYear(), now.getMonth(), 1);
+  const nowMidnight = getMidnightToday(now);
+  const weekStart = getWeekStart(now);
+  const monthStart = getMonthStart(now);
   const tagH = activePair ? wearingHoursInRange(entries, nowMidnight, now) : 0;
   const wocheH = activePair ? wearingHoursInRange(entries, weekStart, now) : 0;
   const monatH = activePair ? wearingHoursInRange(entries, monthStart, now) : 0;
@@ -316,7 +272,7 @@ export default async function AdminUserOverview({ params }: { params: Promise<{ 
             <span className="text-xs font-bold text-indigo-700 bg-indigo-50 border border-indigo-200 px-2 py-0.5 rounded-full mt-0.5 flex-shrink-0">{t("vorgabeActive")}</span>
             <div>
               <p className="text-sm font-semibold text-gray-700">
-                {new Date(activeVorgabe.gueltigAb).toLocaleDateString(dl, { timeZone: APP_TZ })} → {activeVorgabe.gueltigBis ? new Date(activeVorgabe.gueltigBis).toLocaleDateString(dl, { timeZone: APP_TZ }) : tc("open")}
+                {formatDate(activeVorgabe.gueltigAb, dl)} → {activeVorgabe.gueltigBis ? formatDate(activeVorgabe.gueltigBis, dl) : tc("open")}
               </p>
               <div className="flex flex-wrap gap-3 mt-1">
                 {activeVorgabe.minProTagH != null && <span className="text-xs text-gray-600">{td("day")}: <strong>{formatHours(activeVorgabe.minProTagH, dl)}</strong> <span className="text-gray-400">({Math.round((activeVorgabe.minProTagH / 24) * 100)}%)</span></span>}

--- a/src/app/admin/users/[id]/vorgaben/page.tsx
+++ b/src/app/admin/users/[id]/vorgaben/page.tsx
@@ -5,7 +5,7 @@ import VorgabeForm from "../VorgabeForm";
 import VorgabeRow from "../VorgabeRow";
 import UserNav from "../UserNav";
 import { getLocale, getTranslations } from "next-intl/server";
-import { toDateLocale, APP_TZ } from "@/lib/utils";
+import { toDateLocale, formatDate } from "@/lib/utils";
 
 function isActive(v: { gueltigAb: Date; gueltigBis: Date | null }): boolean {
   const now = new Date();
@@ -50,7 +50,7 @@ export default async function VorgabenPage({ params }: { params: Promise<{ id: s
                 userId={id}
                 vorgabeId={v.id}
                 active={isActive(v)}
-                dateLabel={`${new Date(v.gueltigAb).toLocaleDateString(dl, { timeZone: APP_TZ })}${v.gueltigBis ? ` → ${new Date(v.gueltigBis).toLocaleDateString(dl, { timeZone: APP_TZ })}` : ` → ${tc("open")}`}`}
+                dateLabel={`${formatDate(v.gueltigAb, dl)}${v.gueltigBis ? ` → ${formatDate(v.gueltigBis, dl)}` : ` → ${tc("open")}`}`}
                 tagH={v.minProTagH}
                 wocheH={v.minProWocheH}
                 monatH={v.minProMonatH}

--- a/src/app/components/KontrolleBanner.tsx
+++ b/src/app/components/KontrolleBanner.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import Link from "next/link";
+import { AlertCircle, AlertTriangle } from "lucide-react";
 import { formatDateTime, toDateLocale } from "@/lib/utils";
 import { getTranslations, getLocale } from "next-intl/server";
 
@@ -50,7 +51,10 @@ export default async function KontrolleBanner({
 
   const inner = (
     <>
-      <span className="text-xl flex-shrink-0">{overdue ? "🚨" : "⚠"}</span>
+      {overdue
+        ? <AlertCircle size={22} className="flex-shrink-0 text-red-500" />
+        : <AlertTriangle size={22} className="flex-shrink-0 text-amber-500" />
+      }
       <div className="flex-1 min-w-0">
         <p className="text-sm font-bold">{overdue ? t("overdueTitle") : (openLabel ?? defaultOpenLabel)}</p>
         <p className="text-xs opacity-80">

--- a/src/app/components/StatsMain.tsx
+++ b/src/app/components/StatsMain.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 import { prisma } from "@/lib/prisma";
-import { formatDuration, formatDateTime, formatHours, formatMs, toDateLocale, APP_TZ } from "@/lib/utils";
+import { formatDuration, formatDateTime, formatTime, formatHours, formatMs, toDateLocale, APP_TZ } from "@/lib/utils";
 import { KONTROLLE_PILLS } from "@/lib/kontrollePills";
 import CalendarExpand from "./CalendarExpand";
 import { type CalendarMonthData, type CalendarDayData } from "./CalendarContainer";
@@ -287,7 +287,7 @@ export default async function StatsMain({ userId, heading, backHref, backLabel }
           .sort((a, b) => a.startTime.getTime() - b.startTime.getTime())
           .map((e) => ({
             type: e.type,
-            time: e.startTime.toLocaleTimeString(dl, { hour: "2-digit", minute: "2-digit", timeZone: APP_TZ }),
+            time: formatTime(e.startTime, dl),
             note: e.note,
             orgasmusArt: e.orgasmusArt,
           }));
@@ -441,8 +441,8 @@ export default async function StatsMain({ userId, heading, backHref, backLabel }
                   <span className={`text-xs font-medium border rounded-full px-2 py-0.5 flex-shrink-0 ${cls}`}>{label}</span>
                   {k.code && <span className="font-mono font-bold text-orange-500 text-sm">{k.code}</span>}
                   {k.deadline
-                    ? <span className="text-xs text-gray-400 truncate">{t("deadlineLabel")}: {new Date(k.deadline).toLocaleString(dl, { day: "2-digit", month: "2-digit", year: "numeric", hour: "2-digit", minute: "2-digit", timeZone: APP_TZ })}</span>
-                    : <span className="text-xs text-gray-400 truncate">{k.time.toLocaleString(dl, { day: "2-digit", month: "2-digit", year: "numeric", hour: "2-digit", minute: "2-digit", timeZone: APP_TZ })}</span>
+                    ? <span className="text-xs text-gray-400 truncate">{t("deadlineLabel")}: {formatDateTime(new Date(k.deadline), dl)}</span>
+                    : <span className="text-xs text-gray-400 truncate">{formatDateTime(k.time, dl)}</span>
                   }
                   {k.entryTime && k.status !== "rejected" && (
                     <span className="text-xs text-gray-400 ml-auto flex-shrink-0">{t("fulfilled")}: {new Date(k.entryTime).toLocaleString(dl, { day: "2-digit", month: "2-digit", hour: "2-digit", minute: "2-digit", timeZone: APP_TZ })}</span>
@@ -477,7 +477,7 @@ export default async function StatsMain({ userId, heading, backHref, backLabel }
             {unerlaubteOeffnungen.map((e) => (
               <div key={e.id} className="px-5 py-3 flex items-center gap-3">
                 <span className="text-sm tabular-nums text-red-800 font-medium shrink-0">
-                  {e.startTime.toLocaleString(dl, { day: "2-digit", month: "2-digit", year: "numeric", hour: "2-digit", minute: "2-digit", timeZone: APP_TZ })}
+                  {formatDateTime(e.startTime, dl)}
                 </span>
                 {e.note
                   ? <span className="text-sm text-red-600 italic truncate">„{e.note}"</span>

--- a/src/app/components/VersionChecker.tsx
+++ b/src/app/components/VersionChecker.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { RefreshCw } from "lucide-react";
 import { useTranslations } from "next-intl";
 
 const POLL_INTERVAL_MS = 5 * 60 * 1000; // 5 Minuten
@@ -54,7 +55,7 @@ export default function VersionChecker({ buildDate }: { buildDate: string }) {
   return (
     <div className="fixed bottom-20 left-4 right-4 sm:left-auto sm:right-6 sm:w-80 z-50">
       <div className="bg-gray-900 text-white rounded-2xl px-4 py-3 flex items-center gap-3 shadow-xl">
-        <span className="text-lg flex-shrink-0">🔄</span>
+        <RefreshCw size={18} className="flex-shrink-0 text-gray-300 animate-spin" style={{ animationDuration: "2s" }} />
         <div className="flex-1 min-w-0">
           <p className="text-sm font-semibold">{t("title")}</p>
           <p className="text-xs text-gray-400">{t("subtitle")}</p>

--- a/src/app/dashboard/LaufendeSessionCard.tsx
+++ b/src/app/dashboard/LaufendeSessionCard.tsx
@@ -1,5 +1,5 @@
 import { Lock, CheckCircle2, Droplets } from "lucide-react";
-import { formatHours, toDateLocale, APP_TZ } from "@/lib/utils";
+import { formatHours, formatDateTime, formatDate, formatTime, hasExifMismatch, toDateLocale } from "@/lib/utils";
 import { getTranslations, getLocale } from "next-intl/server";
 import { KONTROLLE_PILLS } from "@/lib/kontrollePills";
 import SessionDurationBadge from "./SessionDurationBadge";
@@ -64,25 +64,8 @@ export default async function LaufendeSessionCard({
   const tCommon = await getTranslations("common");
   const dl = toDateLocale(await getLocale());
 
-  const sessionStartStr = sessionStart.toLocaleString(dl, {
-    day: "2-digit",
-    month: "2-digit",
-    year: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-    timeZone: APP_TZ,
-  });
-
-  const sperrzeitStr = sperrzeitEndetAt
-    ? sperrzeitEndetAt.toLocaleString(dl, {
-        day: "2-digit",
-        month: "2-digit",
-        year: "numeric",
-        hour: "2-digit",
-        minute: "2-digit",
-        timeZone: APP_TZ,
-      })
-    : null;
+  const sessionStartStr = formatDateTime(sessionStart, dl);
+  const sperrzeitStr = sperrzeitEndetAt ? formatDateTime(sperrzeitEndetAt, dl) : null;
 
   const hasVorgabe =
     activeVorgabe &&
@@ -151,11 +134,10 @@ export default async function LaufendeSessionCard({
       {/* ── Timeline ── */}
       <div className="divide-y divide-gray-50">
         {events.map((ev, i) => {
-          const dateStr = ev.time.toLocaleDateString(dl, { day: "2-digit", month: "2-digit", year: "numeric", timeZone: APP_TZ });
-          const timeStr = ev.time.toLocaleTimeString(dl, { hour: "2-digit", minute: "2-digit", timeZone: APP_TZ });
-          const exifMismatch = ev.imageExifTime && Math.abs(ev.imageExifTime.getTime() - ev.time.getTime()) > 3600000;
-          const exifStr = exifMismatch
-            ? ev.imageExifTime!.toLocaleString(dl, { day: "2-digit", month: "2-digit", year: "numeric", hour: "2-digit", minute: "2-digit", timeZone: APP_TZ })
+          const dateStr = formatDate(ev.time, dl);
+          const timeStr = formatTime(ev.time, dl);
+          const exifStr = ev.imageExifTime && hasExifMismatch(ev.imageExifTime, ev.time)
+            ? formatDateTime(ev.imageExifTime, dl)
             : null;
           const statusLabel = ev.kontrolleStatus && KONTROLLE_PILLS[ev.kontrolleStatus]
             ? KONTROLLE_PILLS[ev.kontrolleStatus].label
@@ -180,9 +162,7 @@ export default async function LaufendeSessionCard({
                 captureHref: !ev.entryId && ev.type === "kontrolle" && ev.kontrolleCode
                   ? `/dashboard/new/pruefung?code=${ev.kontrolleCode}`
                   : null,
-                deadlineStr: ev.deadline
-                  ? ev.deadline.toLocaleString(dl, { day: "2-digit", month: "2-digit", year: "numeric", hour: "2-digit", minute: "2-digit", timeZone: APP_TZ })
-                  : null,
+                deadlineStr: ev.deadline ? formatDateTime(ev.deadline, dl) : null,
                 isOverdue: ev.kontrolleStatus === "overdue",
                 kontrolleCode: ev.kontrolleCode ?? null,
                 kontrolleKommentar: ev.kontrolleKommentar ?? null,

--- a/src/app/dashboard/OeffnenForm.tsx
+++ b/src/app/dashboard/OeffnenForm.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { toDatetimeLocal, toDateLocale } from "@/lib/utils";
+import { AlertCircle, Lock } from "lucide-react";
 import { useTranslations, useLocale } from "next-intl";
 
 const OEFFNEN_GRUENDE = ["REINIGUNG", "KEYHOLDER", "NOTFALL", "ANDERES"] as const;
@@ -77,7 +78,7 @@ export default function OeffnenForm({ initial, sperrzeitEndetAt }: Props) {
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 px-6">
           <div className="bg-white rounded-2xl shadow-2xl max-w-sm w-full p-6 flex flex-col gap-5">
             <div className="flex items-start gap-3">
-              <span className="text-3xl leading-none">🚨</span>
+              <AlertCircle size={28} className="flex-shrink-0 text-red-500 mt-0.5" />
               <div className="flex flex-col gap-1.5">
                 <p className="font-bold text-gray-900 text-base leading-snug">
                   {t("modalTitle")}
@@ -117,7 +118,7 @@ export default function OeffnenForm({ initial, sperrzeitEndetAt }: Props) {
         {/* Hinweis im Formular bei aktiver Sperrzeit */}
         {isGesperrt && (
           <div className="flex items-start gap-2.5 bg-rose-50 border border-rose-200 rounded-xl px-4 py-3">
-            <span className="text-base leading-none mt-0.5">🔒</span>
+            <Lock size={16} className="flex-shrink-0 text-rose-500 mt-0.5" />
             <div>
               <p className="text-sm font-bold text-rose-800">{t("lockedWarningTitle")}</p>
               <p className="text-xs text-rose-600 mt-0.5">

--- a/src/app/dashboard/SessionEventRow.tsx
+++ b/src/app/dashboard/SessionEventRow.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useRef, useEffect } from "react";
-import { X, Lock, CheckCircle2, Droplets, ImageOff, MoreVertical, Camera } from "lucide-react";
+import { X, Lock, CheckCircle2, Droplets, ImageOff, MoreVertical, Camera, AlertTriangle, AlertCircle } from "lucide-react";
 import { useTranslations } from "next-intl";
 import Link from "next/link";
 import EntryActions from "./EntryActions";
@@ -145,7 +145,10 @@ export default function SessionEventRow({ ev, icon }: { ev: SessionEventData; ic
       : "bg-amber-50 border-amber-200 text-amber-700";
     return (
       <div className={`px-5 py-3 flex items-center gap-3 border-t border-b ${colorCls}`}>
-        <span className="text-lg flex-shrink-0">{ev.isOverdue ? "🚨" : "⚠️"}</span>
+        {ev.isOverdue
+          ? <AlertCircle size={20} className="flex-shrink-0 text-red-500" />
+          : <AlertTriangle size={20} className="flex-shrink-0 text-amber-500" />
+        }
         <div className="flex-1 min-w-0">
           <p className="text-sm font-bold">
             {ev.isOverdue ? t("inspectionOverdue") : t("inspectionRequired")}

--- a/src/app/dashboard/SessionList.tsx
+++ b/src/app/dashboard/SessionList.tsx
@@ -1,5 +1,5 @@
 import { getLocale } from "next-intl/server";
-import { toDateLocale, formatDuration, APP_TZ } from "@/lib/utils";
+import { toDateLocale, formatDuration, formatDate, formatTime, formatDateTime, hasExifMismatch } from "@/lib/utils";
 import { KONTROLLE_PILLS } from "@/lib/kontrollePills";
 import SessionListClient, { SessionListData } from "./SessionListClient";
 
@@ -42,8 +42,8 @@ export default async function SessionList({ pairs, orgasmusEntries }: Props) {
   const sessions: SessionListData[] = pairs.map((pair) => {
     const { verschluss, oeffnen, active, kontrollen } = pair;
 
-    const dateStr = verschluss.startTime.toLocaleDateString(dl, { day: "2-digit", month: "2-digit", year: "numeric", timeZone: APP_TZ });
-    const timeStr = verschluss.startTime.toLocaleTimeString(dl, { hour: "2-digit", minute: "2-digit", timeZone: APP_TZ });
+    const dateStr = formatDate(verschluss.startTime, dl);
+    const timeStr = formatTime(verschluss.startTime, dl);
     const durationStr = oeffnen ? formatDuration(verschluss.startTime, oeffnen.startTime, dl) : null;
 
     const sessionOrgasmen = orgasmusEntries.filter(
@@ -57,13 +57,9 @@ export default async function SessionList({ pairs, orgasmusEntries }: Props) {
         dateStr,
         timeStr,
         imageUrl: verschluss.imageUrl,
-        exifStr: (() => {
-          if (!verschluss.imageExifTime) return null;
-          const diff = Math.abs(verschluss.imageExifTime.getTime() - verschluss.startTime.getTime());
-          return diff > 3_600_000
-            ? verschluss.imageExifTime.toLocaleString(dl, { day: "2-digit", month: "2-digit", year: "numeric", hour: "2-digit", minute: "2-digit", timeZone: APP_TZ })
-            : null;
-        })(),
+        exifStr: verschluss.imageExifTime && hasExifMismatch(verschluss.imageExifTime, verschluss.startTime)
+          ? formatDateTime(verschluss.imageExifTime, dl)
+          : null,
         note: verschluss.note,
         entryId: verschluss.id,
         captureHref: null,
@@ -79,16 +75,14 @@ export default async function SessionList({ pairs, orgasmusEntries }: Props) {
         .map((k) => ({
           type: "kontrolle" as const,
           time: k.time,
-          dateStr: k.time.toLocaleDateString(dl, { day: "2-digit", month: "2-digit", year: "numeric", timeZone: APP_TZ }),
-          timeStr: k.time.toLocaleTimeString(dl, { hour: "2-digit", minute: "2-digit", timeZone: APP_TZ }),
+          dateStr: formatDate(k.time, dl),
+          timeStr: formatTime(k.time, dl),
           imageUrl: k.imageUrl,
           exifStr: null,
           note: null,
           entryId: k.entryId,
           captureHref: !k.entryId && k.code ? `/dashboard/new/pruefung?code=${k.code}` : null,
-          deadlineStr: k.deadline
-            ? k.deadline.toLocaleString(dl, { day: "2-digit", month: "2-digit", year: "numeric", hour: "2-digit", minute: "2-digit", timeZone: APP_TZ })
-            : null,
+          deadlineStr: k.deadline ? formatDateTime(k.deadline, dl) : null,
           isOverdue: k.status === "overdue",
           kontrolleCode: k.code,
           kontrolleKommentar: k.kommentar,
@@ -98,8 +92,8 @@ export default async function SessionList({ pairs, orgasmusEntries }: Props) {
       ...sessionOrgasmen.map((e) => ({
         type: "orgasmus" as const,
         time: e.startTime,
-        dateStr: e.startTime.toLocaleDateString(dl, { day: "2-digit", month: "2-digit", year: "numeric", timeZone: APP_TZ }),
-        timeStr: e.startTime.toLocaleTimeString(dl, { hour: "2-digit", minute: "2-digit", timeZone: APP_TZ }),
+        dateStr: formatDate(e.startTime, dl),
+        timeStr: formatTime(e.startTime, dl),
         imageUrl: e.imageUrl,
         exifStr: null,
         note: e.note,
@@ -124,8 +118,8 @@ export default async function SessionList({ pairs, orgasmusEntries }: Props) {
       events,
       oeffnen: oeffnen
         ? {
-            dateStr: oeffnen.startTime.toLocaleDateString(dl, { day: "2-digit", month: "2-digit", year: "numeric", timeZone: APP_TZ }),
-            timeStr: oeffnen.startTime.toLocaleTimeString(dl, { hour: "2-digit", minute: "2-digit", timeZone: APP_TZ }),
+            dateStr: formatDate(oeffnen.startTime, dl),
+            timeStr: formatTime(oeffnen.startTime, dl),
             grund: oeffnen.oeffnenGrund,
             note: oeffnen.note,
           }

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,6 +1,11 @@
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
-import { formatDuration, formatDateTime, formatHours, wearingHoursInRange, APP_TZ } from "@/lib/utils";
+import {
+  formatDuration, formatDateTime, formatDate, formatHours,
+  wearingHoursInRange, buildPairs, photoStatus, mapKontrolleStatus,
+  getMidnightToday, getWeekStart, getMonthStart, KontrolleStatus, toDateLocale,
+} from "@/lib/utils";
+import { getActiveVorgabe } from "@/lib/queries";
 import { KONTROLLE_PILLS } from "@/lib/kontrollePills";
 import EntryActions from "./EntryActions";
 import PairRow from "./PairRow";
@@ -11,7 +16,6 @@ import { Lock, LockOpen, ClipboardList, Droplets } from "lucide-react";
 import ImageViewer from "@/app/components/ImageViewer";
 import KontrolleBanner from "@/app/components/KontrolleBanner";
 import { getTranslations, getLocale } from "next-intl/server";
-import { toDateLocale } from "@/lib/utils";
 
 type Entry = {
   id: string;
@@ -33,7 +37,7 @@ type KontrolleItem = {
   code: string | null;
   deadline: Date | null;
   kommentar: string | null;
-  status: "open" | "overdue" | "fulfilled" | "ai" | "manual" | "rejected" | "withdrawn";
+  status: KontrolleStatus;
   entryId: string | null;
 };
 
@@ -43,47 +47,6 @@ type Pair = {
   active: boolean;
   kontrollen: KontrolleItem[];
 };
-
-function buildPairs(entries: Entry[], kontrollen: KontrolleItem[]): Pair[] {
-  const asc = [...entries]
-    .filter((e) => ["VERSCHLUSS", "OEFFNEN"].includes(e.type))
-    .sort((a, b) => a.startTime.getTime() - b.startTime.getTime());
-
-  const pairs: Pair[] = [];
-  let pending: Entry | null = null;
-
-  for (const e of asc) {
-    if (e.type === "VERSCHLUSS") {
-      if (pending) pairs.push({ verschluss: pending, oeffnen: null, active: false, kontrollen: [] });
-      pending = e;
-    } else if (e.type === "OEFFNEN" && pending) {
-      pairs.push({ verschluss: pending, oeffnen: e, active: false, kontrollen: [] });
-      pending = null;
-    }
-  }
-  if (pending) pairs.push({ verschluss: pending, oeffnen: null, active: true, kontrollen: [] });
-
-  for (const k of kontrollen) {
-    // Pick the most-recent (latest verschluss) pair that contains k.time
-    const pair = pairs.reduce<Pair | null>((best, p) => {
-      const start = p.verschluss.startTime.getTime();
-      const end = p.oeffnen ? p.oeffnen.startTime.getTime() : Infinity;
-      if (k.time.getTime() < start || k.time.getTime() > end) return best;
-      if (!best) return p;
-      return p.verschluss.startTime > best.verschluss.startTime ? p : best;
-    }, null);
-    if (pair) pair.kontrollen.push(k);
-  }
-
-  return pairs.reverse();
-}
-
-function photoStatus(v: Entry): "no-photo" | "exif-mismatch" | "ok" {
-  if (!v.imageUrl) return "no-photo";
-  if (v.imageExifTime && Math.abs(v.imageExifTime.getTime() - v.startTime.getTime()) > 3600000)
-    return "exif-mismatch";
-  return "ok";
-}
 
 
 export default async function DashboardPage() {
@@ -105,12 +68,9 @@ export default async function DashboardPage() {
   const [entries, alleAnforderungen, activeVorgabe, offeneVerschlussAnf, activeSperrzeit] = await Promise.all([
     prisma.entry.findMany({ where: { userId }, orderBy: { startTime: "desc" } }),
     prisma.kontrollAnforderung.findMany({ where: { userId }, orderBy: { createdAt: "desc" }, include: { entry: true } }),
-    prisma.trainingVorgabe.findFirst({
-      where: { userId, gueltigAb: { lte: now }, OR: [{ gueltigBis: null }, { gueltigBis: { gte: now } }] },
-      orderBy: { gueltigAb: "desc" },
-    }),
+    getActiveVorgabe(userId, now),
     prisma.verschlussAnforderung.findFirst({
-      where: { userId, art: "ANFORDERUNG", fulfilledAt: null, withdrawnAt: null }, // VerschlussAnforderung still has fulfilledAt
+      where: { userId, art: "ANFORDERUNG", fulfilledAt: null, withdrawnAt: null },
     }),
     prisma.verschlussAnforderung.findFirst({
       where: { userId, art: "SPERRZEIT", withdrawnAt: null, endetAt: { gt: now } },
@@ -127,13 +87,7 @@ export default async function DashboardPage() {
     // KontrollAnforderungen (mit FK verknüpft)
     ...alleAnforderungen.map(k => {
       const vs = k.entry?.verifikationStatus ?? null;
-      const status: KontrolleItem["status"] =
-        k.withdrawnAt ? "withdrawn" :
-        !k.entryId ? (k.deadline < new Date() ? "overdue" : "open") :
-        vs === "rejected" ? "rejected" :
-        vs === "manual" ? "manual" :
-        vs === "ai" ? "ai" :
-        "fulfilled";
+      const status = mapKontrolleStatus(k, vs, now);
       return {
         id: k.id,
         time: k.entry ? k.entry.startTime : k.createdAt,
@@ -220,12 +174,9 @@ export default async function DashboardPage() {
       ].sort((a, b) => a.time.getTime() - b.time.getTime())
     : [];
 
-  const nowMidnight = new Date(now);
-  nowMidnight.setHours(0, 0, 0, 0);
-  const weekStart = new Date(now);
-  weekStart.setDate(now.getDate() - ((now.getDay() + 6) % 7));
-  weekStart.setHours(0, 0, 0, 0);
-  const monthStart = new Date(now.getFullYear(), now.getMonth(), 1);
+  const nowMidnight = getMidnightToday(now);
+  const weekStart = getWeekStart(now);
+  const monthStart = getMonthStart(now);
   const tagH = activePair ? wearingHoursInRange(entries, nowMidnight, now) : 0;
   const wocheH = activePair ? wearingHoursInRange(entries, weekStart, now) : 0;
   const monatH = activePair ? wearingHoursInRange(entries, monthStart, now) : 0;
@@ -264,7 +215,7 @@ export default async function DashboardPage() {
             )}
             {offeneVerschlussAnf.endetAt && (
               <p className="text-xs text-indigo-500">
-                {t("lockUntil", { date: new Date(offeneVerschlussAnf.endetAt).toLocaleString(dl, { day: "2-digit", month: "2-digit", year: "numeric", hour: "2-digit", minute: "2-digit", timeZone: APP_TZ }) })}
+                {t("lockUntil", { date: formatDateTime(offeneVerschlussAnf.endetAt, dl) })}
               </p>
             )}
           </div>
@@ -282,7 +233,7 @@ export default async function DashboardPage() {
             )}
             {activeSperrzeit.endetAt && (
               <p className="text-xs text-rose-500">
-                {t("openingForbiddenUntil", { date: new Date(activeSperrzeit.endetAt).toLocaleString(dl, { day: "2-digit", month: "2-digit", year: "numeric", hour: "2-digit", minute: "2-digit", timeZone: APP_TZ }) })}
+                {t("openingForbiddenUntil", { date: formatDateTime(activeSperrzeit.endetAt, dl) })}
               </p>
             )}
           </div>
@@ -319,7 +270,7 @@ export default async function DashboardPage() {
               <span className="text-xs font-bold text-indigo-700 bg-indigo-50 border border-indigo-200 px-2 py-0.5 rounded-full mt-0.5 flex-shrink-0">{tCommon("active")}</span>
               <div>
                 <p className="text-sm font-semibold text-gray-700">
-                  {new Date(activeVorgabe.gueltigAb).toLocaleDateString(dl, { timeZone: APP_TZ })} → {activeVorgabe.gueltigBis ? new Date(activeVorgabe.gueltigBis).toLocaleDateString(dl, { timeZone: APP_TZ }) : tCommon("open")}
+                  {formatDate(activeVorgabe.gueltigAb, dl)} → {activeVorgabe.gueltigBis ? formatDate(activeVorgabe.gueltigBis, dl) : tCommon("open")}
                 </p>
                 <div className="flex flex-wrap gap-3 mt-1">
                   {activeVorgabe.minProTagH != null && <span className="text-xs text-gray-600">{t("day")}: <strong>{formatHours(activeVorgabe.minProTagH, dl)}</strong> <span className="text-gray-400">({Math.round((activeVorgabe.minProTagH / 24) * 100)}%)</span></span>}

--- a/src/data/changelog.json
+++ b/src/data/changelog.json
@@ -1,5 +1,15 @@
 [
   {
+    "version": "1.5.5",
+    "date": "2026-03-22",
+    "changes": [
+      {
+        "type": "chore",
+        "text": "Refactoring: Datums-/Zeitformatierung, buildPairs, photoStatus, mapKontrolleStatus, Datumsbereiche und getActiveVorgabe zentral in utils.ts / queries.ts verwaltet – kein duplizierter Code mehr in Page-Komponenten"
+      }
+    ]
+  },
+  {
     "version": "1.5.4",
     "date": "2026-03-22",
     "changes": [

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -1,0 +1,13 @@
+import { prisma } from "@/lib/prisma";
+
+/** Returns the currently active TrainingVorgabe for a user, or null. */
+export async function getActiveVorgabe(userId: string, now: Date) {
+  return prisma.trainingVorgabe.findFirst({
+    where: {
+      userId,
+      gueltigAb: { lte: now },
+      OR: [{ gueltigBis: null }, { gueltigBis: { gte: now } }],
+    },
+    orderBy: { gueltigAb: "desc" },
+  });
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -48,16 +48,111 @@ export function toDateLocale(locale: string): string {
 /** App timezone – all server-side date formatting uses this. */
 export const APP_TZ = "Europe/Zurich";
 
+/** dd.mm.yyyy, HH:mm – server-side, always CET/CEST */
 export function formatDateTime(date: Date | string, locale = "de-CH"): string {
-  const d = new Date(date);
-  return d.toLocaleString(locale, {
-    day: "2-digit",
-    month: "2-digit",
-    year: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-    timeZone: APP_TZ,
+  return new Date(date).toLocaleString(locale, {
+    day: "2-digit", month: "2-digit", year: "numeric",
+    hour: "2-digit", minute: "2-digit", timeZone: APP_TZ,
   });
+}
+
+/** dd.mm.yyyy – server-side, always CET/CEST */
+export function formatDate(date: Date | string, locale = "de-CH"): string {
+  return new Date(date).toLocaleDateString(locale, {
+    day: "2-digit", month: "2-digit", year: "numeric", timeZone: APP_TZ,
+  });
+}
+
+/** HH:mm – server-side, always CET/CEST */
+export function formatTime(date: Date | string, locale = "de-CH"): string {
+  return new Date(date).toLocaleTimeString(locale, {
+    hour: "2-digit", minute: "2-digit", timeZone: APP_TZ,
+  });
+}
+
+/** Today at 00:00:00 local time */
+export function getMidnightToday(now: Date): Date {
+  const d = new Date(now);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+/** Start of the current ISO week (Monday 00:00:00 local time) */
+export function getWeekStart(now: Date): Date {
+  const d = new Date(now);
+  d.setDate(d.getDate() - ((d.getDay() + 6) % 7));
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+/** First day of the current month at 00:00:00 local time */
+export function getMonthStart(now: Date): Date {
+  return new Date(now.getFullYear(), now.getMonth(), 1);
+}
+
+/** True if EXIF time differs from entry time by more than 1 hour */
+export function hasExifMismatch(exifTime: Date, startTime: Date): boolean {
+  return Math.abs(exifTime.getTime() - startTime.getTime()) > 3_600_000;
+}
+
+export type KontrolleStatus = "open" | "overdue" | "fulfilled" | "ai" | "manual" | "rejected" | "withdrawn";
+
+/** Derives KontrolleStatus from a KontrollAnforderung and its linked entry's verifikationStatus */
+export function mapKontrolleStatus(
+  k: { withdrawnAt: Date | null; entryId: string | null; deadline: Date },
+  verifikationStatus: string | null,
+  now: Date
+): KontrolleStatus {
+  if (k.withdrawnAt) return "withdrawn";
+  if (!k.entryId) return k.deadline < now ? "overdue" : "open";
+  if (verifikationStatus === "rejected") return "rejected";
+  if (verifikationStatus === "manual") return "manual";
+  if (verifikationStatus === "ai") return "ai";
+  return "fulfilled";
+}
+
+/** Builds Verschluss/Oeffnen pairs with associated Kontrollen, newest first */
+export function buildPairs<
+  E extends { id: string; type: string; startTime: Date },
+  K extends { time: Date }
+>(entries: E[], kontrollen: K[]): { verschluss: E; oeffnen: E | null; active: boolean; kontrollen: K[] }[] {
+  const asc = [...entries]
+    .filter((e) => e.type === "VERSCHLUSS" || e.type === "OEFFNEN")
+    .sort((a, b) => a.startTime.getTime() - b.startTime.getTime());
+
+  const pairs: { verschluss: E; oeffnen: E | null; active: boolean; kontrollen: K[] }[] = [];
+  let pending: E | null = null;
+
+  for (const e of asc) {
+    if (e.type === "VERSCHLUSS") {
+      if (pending) pairs.push({ verschluss: pending, oeffnen: null, active: false, kontrollen: [] });
+      pending = e;
+    } else if (e.type === "OEFFNEN" && pending) {
+      pairs.push({ verschluss: pending, oeffnen: e, active: false, kontrollen: [] });
+      pending = null;
+    }
+  }
+  if (pending) pairs.push({ verschluss: pending, oeffnen: null, active: true, kontrollen: [] });
+
+  for (const k of kontrollen) {
+    const pair = pairs.reduce<{ verschluss: E; oeffnen: E | null; active: boolean; kontrollen: K[] } | null>((best, p) => {
+      const start = p.verschluss.startTime.getTime();
+      const end = p.oeffnen ? p.oeffnen.startTime.getTime() : Infinity;
+      if (k.time.getTime() < start || k.time.getTime() > end) return best;
+      if (!best) return p;
+      return p.verschluss.startTime > best.verschluss.startTime ? p : best;
+    }, null);
+    if (pair) pair.kontrollen.push(k);
+  }
+
+  return pairs.reverse();
+}
+
+/** Returns photo verification status for an entry */
+export function photoStatus(v: { imageUrl: string | null; imageExifTime: Date | null; startTime: Date }): "no-photo" | "exif-mismatch" | "ok" {
+  if (!v.imageUrl) return "no-photo";
+  if (v.imageExifTime && hasExifMismatch(v.imageExifTime, v.startTime)) return "exif-mismatch";
+  return "ok";
 }
 
 /** Berechnet Tragedauer in Stunden innerhalb eines Zeitraums. */


### PR DESCRIPTION
## Summary
- `formatDate` / `formatTime` in `utils.ts` — ersetzen alle verstreuten `toLocaleDateString`/`toLocaleTimeString`-Aufrufe mit `timeZone: APP_TZ`
- `buildPairs` / `photoStatus` aus `dashboard/page.tsx` und `admin/users/[id]/page.tsx` extrahiert (waren identisch)
- `mapKontrolleStatus` — duplizierte Status-Logik in einer Funktion zentralisiert
- `getMidnightToday` / `getWeekStart` / `getMonthStart` — Datumsbereichs-Berechnungen vereinheitlicht
- `hasExifMismatch` — EXIF-Differenzprüfung zentralisiert
- `KontrolleStatus` Typ exportiert
- Neues `src/lib/queries.ts` mit `getActiveVorgabe()` (Prisma-Query aus 2 Pages extrahiert)

## Test plan
- [ ] Build fehlerfrei (`npm run build`) ✅
- [ ] Dashboard: Session-Karte, Vorgaben, Banners zeigen korrekte Zeiten (CET/CEST)
- [ ] Admin: Benutzerliste, User-Detailseite, Vorgaben zeigen korrekte Zeiten
- [ ] Statistiken / Kalender funktionieren wie bisher

🤖 Generated with [Claude Code](https://claude.com/claude-code)