### PR TITLE
fix: show kontrolle kommentar in lists and image lightbox

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kg-app",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/admin/kontrollen/page.tsx
+++ b/src/app/admin/kontrollen/page.tsx
@@ -96,7 +96,7 @@ export default async function AdminKontrollenPage({
               <div key={k.id} className="px-5 py-4 flex flex-col sm:flex-row sm:items-center gap-3">
                 {k.entry?.imageUrl && (
                   <ImageViewer src={k.entry.imageUrl} alt={t("kontrollenTitle")} width={64} height={64}
-                    className="w-14 h-14 rounded-xl object-cover flex-shrink-0" />
+                    className="w-14 h-14 rounded-xl object-cover flex-shrink-0" kommentar={k.kommentar} />
                 )}
                 <div className="flex-1 min-w-0 flex flex-col gap-1">
                   <div className="flex items-center gap-2 flex-wrap">

--- a/src/app/admin/users/[id]/kontrollen/page.tsx
+++ b/src/app/admin/users/[id]/kontrollen/page.tsx
@@ -100,7 +100,7 @@ export default async function AdminUserKontrollenPage({ params }: { params: Prom
               <div key={k.id} className="px-5 py-4 flex flex-col sm:flex-row sm:items-center gap-3">
                 {k.entry?.imageUrl && (
                   <ImageViewer src={k.entry.imageUrl} alt="Kontroll-Foto" width={64} height={64}
-                    className="w-14 h-14 rounded-xl object-cover flex-shrink-0" />
+                    className="w-14 h-14 rounded-xl object-cover flex-shrink-0" kommentar={k.kommentar} />
                 )}
                 <div className="flex-1 min-w-0 flex flex-col gap-1">
                   <div className="flex items-center gap-2 flex-wrap">

--- a/src/app/admin/users/[id]/page.tsx
+++ b/src/app/admin/users/[id]/page.tsx
@@ -40,6 +40,7 @@ type KontrolleItem = {
   code: string | null;
   deadline: Date | null;
   kommentar: string | null;
+  note: string | null;
   status: KontrolleStatus;
   entryId: string | null;
 };
@@ -90,6 +91,7 @@ export default async function AdminUserOverview({ params }: { params: Promise<{ 
         code: k.code,
         deadline: k.deadline,
         kommentar: k.kommentar ?? null,
+        note: k.entry?.note ?? null,
         status,
         entryId: k.entry?.id ?? null,
       };
@@ -103,6 +105,7 @@ export default async function AdminUserOverview({ params }: { params: Promise<{ 
         code: e.kontrollCode,
         deadline: null as Date | null,
         kommentar: null as string | null,
+        note: e.note,
         status: (e.verifikationStatus === "ai" ? "ai" : "fulfilled") as KontrolleItem["status"],
         entryId: e.id,
       })),
@@ -155,7 +158,7 @@ export default async function AdminUserOverview({ params }: { params: Promise<{ 
             time: k.time,
             imageUrl: k.imageUrl,
             imageExifTime: null,
-            note: null,
+            note: k.note,
             entryId: k.entryId,
             deadline: k.deadline,
             kontrolleKommentar: k.kommentar,

--- a/src/app/admin/users/[id]/page.tsx
+++ b/src/app/admin/users/[id]/page.tsx
@@ -357,7 +357,7 @@ export default async function AdminUserOverview({ params }: { params: Promise<{ 
                 <div key={k.id} className="px-5 py-3 flex items-center gap-3 hover:bg-gray-50/60 transition">
                   {k.imageUrl && (
                     <ImageViewer src={k.imageUrl} alt={ts("inspections")} width={40} height={40}
-                      className="w-10 h-10 rounded-xl object-cover flex-shrink-0" />
+                      className="w-10 h-10 rounded-xl object-cover flex-shrink-0" kommentar={k.kommentar} />
                   )}
                   <div className="flex-1 min-w-0 flex items-center gap-2 flex-wrap">
                     {pill && <span className={`text-xs font-medium border rounded-lg px-2 py-0.5 flex-shrink-0 ${pill.cls}`}>{pillLabels[k.status] ?? pill.label}</span>}
@@ -365,6 +365,9 @@ export default async function AdminUserOverview({ params }: { params: Promise<{ 
                     <span className="text-xs text-gray-400 truncate">{formatDateTime(k.time, dl)}</span>
                     {k.deadline && (
                       <span className="text-xs text-gray-300 truncate">{t("frist")}: {formatDateTime(k.deadline, dl)}</span>
+                    )}
+                    {k.kommentar && (
+                      <span className="text-xs text-amber-700 truncate w-full">{k.kommentar}</span>
                     )}
                   </div>
                   {k.entryId && <EntryActions id={k.entryId} editHref={`/dashboard/edit/${k.entryId}`} />}

--- a/src/app/components/ImageViewer.tsx
+++ b/src/app/components/ImageViewer.tsx
@@ -11,9 +11,10 @@ interface Props {
   width: number;
   height: number;
   className?: string;
+  kommentar?: string | null;
 }
 
-export default function ImageViewer({ src, alt, width, height, className }: Props) {
+export default function ImageViewer({ src, alt, width, height, className, kommentar }: Props) {
   const t = useTranslations("common");
   const resolvedAlt = alt ?? t("photo");
   const [open, setOpen] = useState(false);
@@ -75,6 +76,13 @@ export default function ImageViewer({ src, alt, width, height, className }: Prop
               onError={() => setError(true)}
             />
           </div>
+
+          {/* Kommentar footer */}
+          {kommentar && (
+            <div className="flex-shrink-0 bg-white/10 px-4 py-3" onClick={(e) => e.stopPropagation()}>
+              <p className="text-sm text-white/90">{kommentar}</p>
+            </div>
+          )}
         </div>
       )}
     </>

--- a/src/app/dashboard/SessionList.tsx
+++ b/src/app/dashboard/SessionList.tsx
@@ -9,6 +9,7 @@ interface KontrolleItem {
   code: string | null;
   deadline: Date | null;
   kommentar: string | null;
+  note: string | null;
   status: string;
   entryId: string | null;
 }
@@ -79,7 +80,7 @@ export default async function SessionList({ pairs, orgasmusEntries }: Props) {
           timeStr: formatTime(k.time, dl),
           imageUrl: k.imageUrl,
           exifStr: null,
-          note: null,
+          note: k.note,
           entryId: k.entryId,
           captureHref: !k.entryId && k.code ? `/dashboard/new/pruefung?code=${k.code}` : null,
           deadlineStr: k.deadline ? formatDateTime(k.deadline, dl) : null,

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -357,7 +357,7 @@ export default async function DashboardPage() {
                   <div key={k.id} className="px-5 py-3 flex items-center gap-3 hover:bg-gray-50/60 transition">
                     {k.imageUrl && (
                       <ImageViewer src={k.imageUrl} alt="Kontrolle" width={40} height={40}
-                        className="w-10 h-10 rounded-xl object-cover flex-shrink-0" />
+                        className="w-10 h-10 rounded-xl object-cover flex-shrink-0" kommentar={k.kommentar} />
                     )}
                     <div className="flex-1 min-w-0 flex items-center gap-2 flex-wrap">
                       {pill && <span className={`text-xs font-medium border rounded-lg px-2 py-0.5 flex-shrink-0 ${pill.cls}`}>{ta(PILL_LABEL_KEYS[k.status] ?? "pillOpen")}</span>}
@@ -365,6 +365,9 @@ export default async function DashboardPage() {
                       <span className="text-xs text-gray-400 truncate">{formatDateTime(k.time, dl)}</span>
                       {k.deadline && (
                         <span className="text-xs text-gray-300 truncate">{t("deadline")}: {formatDateTime(k.deadline, dl)}</span>
+                      )}
+                      {k.kommentar && (
+                        <span className="text-xs text-amber-700 truncate w-full">{k.kommentar}</span>
                       )}
                     </div>
                     {k.entryId && <EntryActions id={k.entryId} editHref={`/dashboard/edit/${k.entryId}`} />}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -37,6 +37,7 @@ type KontrolleItem = {
   code: string | null;
   deadline: Date | null;
   kommentar: string | null;
+  note: string | null;
   status: KontrolleStatus;
   entryId: string | null;
 };
@@ -95,6 +96,7 @@ export default async function DashboardPage() {
         code: k.code,
         deadline: k.deadline,
         kommentar: k.kommentar ?? null,
+        note: k.entry?.note ?? null,
         status,
         entryId: k.entry?.id ?? null,
       };
@@ -109,6 +111,7 @@ export default async function DashboardPage() {
         code: e.kontrollCode,
         deadline: null as Date | null,
         kommentar: null as string | null,
+        note: e.note,
         status: (e.verifikationStatus === "ai" ? "ai" : "fulfilled") as KontrolleItem["status"],
         entryId: e.id,
       })),
@@ -153,7 +156,7 @@ export default async function DashboardPage() {
             time: k.time,
             imageUrl: k.imageUrl,
             imageExifTime: null,
-            note: null,
+            note: k.note,
             entryId: k.entryId,
             deadline: k.deadline,
             kontrolleKommentar: k.kommentar,

--- a/src/data/changelog.json
+++ b/src/data/changelog.json
@@ -1,5 +1,15 @@
 [
   {
+    "version": "1.5.6",
+    "date": "2026-03-22",
+    "changes": [
+      {
+        "type": "fix",
+        "text": "Kontrolle-Kommentar wird jetzt in der Kontrollliste (Dashboard + Admin) und im Foto-Lightbox angezeigt"
+      }
+    ]
+  },
+  {
     "version": "1.5.5",
     "date": "2026-03-22",
     "changes": [


### PR DESCRIPTION
## Summary
- Display kommentar text in kontrollen list rows (dashboard + admin user overview)
- Add optional `kommentar` prop to `ImageViewer` so the photo lightbox shows the comment
- Pass kommentar to `ImageViewer` in all kontrolle contexts

## Test plan
- [ ] Open dashboard with an active kontrolle that has a kommentar → kommentar text appears below deadline in the list row
- [ ] Click the photo thumbnail → lightbox shows kommentar text at the bottom
- [ ] Admin user overview kontrollen section → kommentar visible in list and lightbox
- [ ] Admin kontrollen pages → lightbox shows kommentar

🤖 Generated with [Claude Code](https://claude.com/claude-code)