### PR TITLE
feat: Reinigungsunterbrechungen (v1.7.0)

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -105,6 +105,7 @@
     "sessionKontrolle": "Kontrolle",
     "sessionSelbstkontrolle": "Selbstkontrolle",
     "sessionOrgasmus": "Orgasmus",
+    "sessionReinigung": "Reinigungspause",
     "captureNow": "Jetzt erfassen",
     "inspectionOverdue": "Kontrolle überfällig",
     "overduePrefix": "Überfällig seit",
@@ -198,7 +199,8 @@
     "reinigungErlaubt": "Reinigungsunterbrechung zulassen",
     "reinigungMaxMinuten": "Maximale Reinigungsdauer",
     "minutes": "Minuten",
-    "saved": "Gespeichert"
+    "saved": "Gespeichert",
+    "saveBtnGeneric": "Speichern"
   },
   "changelog": {
     "title": "Changelog",

--- a/messages/de.json
+++ b/messages/de.json
@@ -193,7 +193,12 @@
     "saving": "Wird gespeichert…",
     "signOut": "Abmelden",
     "signOutConfirm": "Wirklich abmelden?",
-    "language": "Sprache"
+    "language": "Sprache",
+    "reinigungTitle": "Reinigungsunterbrechung",
+    "reinigungErlaubt": "Reinigungsunterbrechung zulassen",
+    "reinigungMaxMinuten": "Maximale Reinigungsdauer",
+    "minutes": "Minuten",
+    "saved": "Gespeichert"
   },
   "changelog": {
     "title": "Changelog",

--- a/messages/en.json
+++ b/messages/en.json
@@ -105,6 +105,7 @@
     "sessionKontrolle": "Inspection",
     "sessionSelbstkontrolle": "Self-inspection",
     "sessionOrgasmus": "Orgasm",
+    "sessionReinigung": "Cleaning break",
     "captureNow": "Capture now",
     "inspectionOverdue": "Inspection overdue",
     "overduePrefix": "Overdue since",
@@ -198,7 +199,8 @@
     "reinigungErlaubt": "Allow cleaning interruptions",
     "reinigungMaxMinuten": "Maximum cleaning duration",
     "minutes": "minutes",
-    "saved": "Saved"
+    "saved": "Saved",
+    "saveBtnGeneric": "Save"
   },
   "changelog": {
     "title": "Changelog",

--- a/messages/en.json
+++ b/messages/en.json
@@ -193,7 +193,12 @@
     "saving": "Saving…",
     "signOut": "Sign out",
     "signOutConfirm": "Really sign out?",
-    "language": "Language"
+    "language": "Language",
+    "reinigungTitle": "Cleaning interruption",
+    "reinigungErlaubt": "Allow cleaning interruptions",
+    "reinigungMaxMinuten": "Maximum cleaning duration",
+    "minutes": "minutes",
+    "saved": "Saved"
   },
   "changelog": {
     "title": "Changelog",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kg-app",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kg-app",
-  "version": "1.6.2",
+  "version": "1.7.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/prisma/migrations/20260322210730_add_reinigung_settings/migration.sql
+++ b/prisma/migrations/20260322210730_add_reinigung_settings/migration.sql
@@ -1,0 +1,20 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_User" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "username" TEXT NOT NULL,
+    "passwordHash" TEXT NOT NULL,
+    "role" TEXT NOT NULL DEFAULT 'user',
+    "email" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "reinigungErlaubt" BOOLEAN NOT NULL DEFAULT false,
+    "reinigungMaxMinuten" INTEGER NOT NULL DEFAULT 15
+);
+INSERT INTO "new_User" ("createdAt", "email", "id", "passwordHash", "role", "username") SELECT "createdAt", "email", "id", "passwordHash", "role", "username" FROM "User";
+DROP TABLE "User";
+ALTER TABLE "new_User" RENAME TO "User";
+CREATE UNIQUE INDEX "User_username_key" ON "User"("username");
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -15,6 +15,8 @@ model User {
   role                  String                 @default("user")
   email                 String?                @unique
   createdAt             DateTime               @default(now())
+  reinigungErlaubt      Boolean                @default(false)
+  reinigungMaxMinuten   Int                    @default(15)
   entries               Entry[]
   vorgaben              TrainingVorgabe[]
   passwordResetTokens   PasswordResetToken[]

--- a/src/app/admin/ReinigungToggle.tsx
+++ b/src/app/admin/ReinigungToggle.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+export default function ReinigungToggle({
+  userId,
+  initialErlaubt,
+  initialMaxMinuten,
+}: {
+  userId: string;
+  initialErlaubt: boolean;
+  initialMaxMinuten: number;
+}) {
+  const router = useRouter();
+  const [erlaubt, setErlaubt] = useState(initialErlaubt);
+  const [maxMin, setMaxMin] = useState(initialMaxMinuten);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+
+  async function save(newErlaubt: boolean, newMaxMin: number) {
+    setSaving(true);
+    await fetch(`/api/admin/users/${userId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ reinigungErlaubt: newErlaubt, reinigungMaxMinuten: newMaxMin }),
+    });
+    setSaving(false);
+    setSaved(true);
+    setTimeout(() => setSaved(false), 2000);
+    router.refresh();
+  }
+
+  function handleToggle(checked: boolean) {
+    setErlaubt(checked);
+    save(checked, maxMin);
+  }
+
+  function handleMinuten(e: React.ChangeEvent<HTMLInputElement>) {
+    const val = Math.max(1, Math.min(120, Number(e.target.value) || 15));
+    setMaxMin(val);
+  }
+
+  return (
+    <div className="flex items-center gap-2 flex-wrap">
+      <label className="flex items-center gap-1.5 cursor-pointer select-none">
+        <input
+          type="checkbox"
+          checked={erlaubt}
+          onChange={(e) => handleToggle(e.target.checked)}
+          disabled={saving}
+          className="w-4 h-4 rounded accent-indigo-600"
+        />
+        <span className="text-xs font-medium text-gray-500">Reinigung</span>
+      </label>
+      {erlaubt && (
+        <div className="flex items-center gap-1">
+          <input
+            type="number"
+            min={1}
+            max={120}
+            value={maxMin}
+            onChange={handleMinuten}
+            onBlur={() => save(erlaubt, maxMin)}
+            disabled={saving}
+            className="w-14 border border-gray-200 rounded-lg px-2 py-1 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-indigo-400 bg-gray-50"
+          />
+          <span className="text-xs text-gray-400">min</span>
+        </div>
+      )}
+      {saved && <span className="text-xs text-emerald-600">✓</span>}
+    </div>
+  );
+}

--- a/src/app/admin/users/[id]/page.tsx
+++ b/src/app/admin/users/[id]/page.tsx
@@ -12,6 +12,7 @@ import { getActiveVorgabe } from "@/lib/queries";
 import { KONTROLLE_PILLS, ANFORDERUNG_PILLS, VERIFIKATION_PILLS } from "@/lib/kontrollePills";
 import ChangePasswordButton from "@/app/admin/ChangePasswordButton";
 import ChangeEmailButton from "@/app/admin/ChangeEmailButton";
+import ReinigungToggle from "@/app/admin/ReinigungToggle";
 import PairRow from "@/app/dashboard/PairRow";
 import StatusBanner from "@/app/dashboard/StatusBanner";
 import LaufendeSessionCard from "@/app/dashboard/LaufendeSessionCard";
@@ -70,19 +71,18 @@ export default async function AdminUserOverview({ params }: { params: Promise<{ 
 
   logAccess(session?.user.name ?? "?", `/admin/users/${user.username}`);
   const now = new Date();
-  const [entries, alleAnforderungen, activeVorgabe, activeSperrzeit, userSettings] = await Promise.all([
+  const [entries, alleAnforderungen, activeVorgabe, activeSperrzeit] = await Promise.all([
     prisma.entry.findMany({ where: { userId: id }, orderBy: { startTime: "desc" } }),
     prisma.kontrollAnforderung.findMany({ where: { userId: id }, orderBy: { createdAt: "desc" }, include: { entry: true } }),
     getActiveVorgabe(id, now),
     prisma.verschlussAnforderung.findFirst({
       where: { userId: id, art: "SPERRZEIT", withdrawnAt: null, endetAt: { gt: now } },
     }),
-    prisma.user.findUnique({ where: { id }, select: { reinigungErlaubt: true, reinigungMaxMinuten: true } }),
   ]);
 
   const reinigung: ReinigungSettings = {
-    erlaubt: userSettings?.reinigungErlaubt ?? false,
-    maxMinuten: userSettings?.reinigungMaxMinuten ?? 15,
+    erlaubt: user.reinigungErlaubt,
+    maxMinuten: user.reinigungMaxMinuten,
   };
 
   const offeneKontrolle = alleAnforderungen.find(k => !k.entryId && !k.withdrawnAt) ?? null;
@@ -186,6 +186,15 @@ export default async function AdminUserOverview({ params }: { params: Promise<{ 
             entryId: e.id,
             orgasmusArt: e.orgasmusArt,
           })),
+        ...activePair.interruptions.map((intr) => ({
+          type: "reinigung" as const,
+          time: intr.oeffnen.startTime,
+          imageUrl: null,
+          imageExifTime: null,
+          note: intr.oeffnen.note,
+          entryId: null,
+          pauseDurationStr: formatDuration(intr.oeffnen.startTime, intr.verschluss.startTime, dl),
+        })),
       ].sort((a, b) => a.time.getTime() - b.time.getTime())
     : [];
 
@@ -217,9 +226,16 @@ export default async function AdminUserOverview({ params }: { params: Promise<{ 
             }
           </div>
         </div>
-        <div className="flex items-center gap-2">
-          <ChangeEmailButton userId={user.id} currentEmail={user.email ?? null} />
-          <ChangePasswordButton userId={user.id} />
+        <div className="flex flex-col gap-2 items-end">
+          <div className="flex items-center gap-2">
+            <ChangeEmailButton userId={user.id} currentEmail={user.email ?? null} />
+            <ChangePasswordButton userId={user.id} />
+          </div>
+          <ReinigungToggle
+            userId={user.id}
+            initialErlaubt={user.reinigungErlaubt}
+            initialMaxMinuten={user.reinigungMaxMinuten}
+          />
         </div>
       </div>
 

--- a/src/app/admin/users/[id]/page.tsx
+++ b/src/app/admin/users/[id]/page.tsx
@@ -3,9 +3,10 @@ import { logAccess } from "@/lib/serverLog";
 import { prisma } from "@/lib/prisma";
 import {
   formatDuration, formatDateTime, formatDate, formatHours, toDateLocale,
-  wearingHoursInRange, buildPairs, photoStatus,
+  wearingHoursInRange, buildPairs, interruptionPauseMs, photoStatus,
   mapAnforderungStatus, mapVerifikationStatus,
   getMidnightToday, getWeekStart, getMonthStart,
+  type ReinigungSettings,
 } from "@/lib/utils";
 import { getActiveVorgabe } from "@/lib/queries";
 import { KONTROLLE_PILLS, ANFORDERUNG_PILLS, VERIFIKATION_PILLS } from "@/lib/kontrollePills";
@@ -52,6 +53,7 @@ type Pair = {
   oeffnen: Entry | null;
   active: boolean;
   kontrollen: KontrolleItem[];
+  interruptions: { oeffnen: Entry; verschluss: Entry }[];
 };
 
 export default async function AdminUserOverview({ params }: { params: Promise<{ id: string }> }) {
@@ -68,14 +70,20 @@ export default async function AdminUserOverview({ params }: { params: Promise<{ 
 
   logAccess(session?.user.name ?? "?", `/admin/users/${user.username}`);
   const now = new Date();
-  const [entries, alleAnforderungen, activeVorgabe, activeSperrzeit] = await Promise.all([
+  const [entries, alleAnforderungen, activeVorgabe, activeSperrzeit, userSettings] = await Promise.all([
     prisma.entry.findMany({ where: { userId: id }, orderBy: { startTime: "desc" } }),
     prisma.kontrollAnforderung.findMany({ where: { userId: id }, orderBy: { createdAt: "desc" }, include: { entry: true } }),
     getActiveVorgabe(id, now),
     prisma.verschlussAnforderung.findFirst({
       where: { userId: id, art: "SPERRZEIT", withdrawnAt: null, endetAt: { gt: now } },
     }),
+    prisma.user.findUnique({ where: { id }, select: { reinigungErlaubt: true, reinigungMaxMinuten: true } }),
   ]);
+
+  const reinigung: ReinigungSettings = {
+    erlaubt: userSettings?.reinigungErlaubt ?? false,
+    maxMinuten: userSettings?.reinigungMaxMinuten ?? 15,
+  };
 
   const offeneKontrolle = alleAnforderungen.find(k => !k.entryId && !k.withdrawnAt) ?? null;
 
@@ -118,10 +126,11 @@ export default async function AdminUserOverview({ params }: { params: Promise<{ 
     ? { type: latest.type as "VERSCHLUSS" | "OEFFNEN", since: latest.startTime.toISOString() }
     : null;
 
-  const pairs = buildPairs(entries, kontrollItems);
+  const pairs = buildPairs(entries, kontrollItems, reinigung);
   const completedPairs = pairs.filter((p) => p.oeffnen);
   const totalMs = completedPairs.reduce(
-    (s, p) => s + p.oeffnen!.startTime.getTime() - p.verschluss.startTime.getTime(), 0
+    (s, p) => s + (p.oeffnen!.startTime.getTime() - p.verschluss.startTime.getTime()) - interruptionPauseMs(p.interruptions),
+    0
   );
   const totalFormatted = completedPairs.length ? formatDuration(new Date(0), new Date(totalMs), dl) : "–";
   const orgasmusEntries = entries
@@ -183,9 +192,9 @@ export default async function AdminUserOverview({ params }: { params: Promise<{ 
   const nowMidnight = getMidnightToday(now);
   const weekStart = getWeekStart(now);
   const monthStart = getMonthStart(now);
-  const tagH = activePair ? wearingHoursInRange(entries, nowMidnight, now) : 0;
-  const wocheH = activePair ? wearingHoursInRange(entries, weekStart, now) : 0;
-  const monatH = activePair ? wearingHoursInRange(entries, monthStart, now) : 0;
+  const tagH = activePair ? wearingHoursInRange(entries, nowMidnight, now, reinigung) : 0;
+  const wocheH = activePair ? wearingHoursInRange(entries, weekStart, now, reinigung) : 0;
+  const monatH = activePair ? wearingHoursInRange(entries, monthStart, now, reinigung) : 0;
 
   return (
     <main className="w-full max-w-5xl px-6 py-8 flex flex-col gap-6">
@@ -218,6 +227,7 @@ export default async function AdminUserOverview({ params }: { params: Promise<{ 
       {activePair ? (
         <LaufendeSessionCard
           sessionStart={activePair.verschluss.startTime}
+          interruptionPausedMs={interruptionPauseMs(activePair.interruptions)}
           now={now}
           events={sessionEvents}
           sperrzeitEndetAt={activeSperrzeit?.endetAt ?? null}

--- a/src/app/admin/users/[id]/page.tsx
+++ b/src/app/admin/users/[id]/page.tsx
@@ -19,6 +19,7 @@ import LaufendeSessionCard from "@/app/dashboard/LaufendeSessionCard";
 import KontrolleBanner from "@/app/components/KontrolleBanner";
 import ImageViewer from "@/app/components/ImageViewer";
 import EntryActions from "@/app/dashboard/EntryActions";
+import SessionList from "@/app/dashboard/SessionList";
 import { Lock, LockOpen, ClipboardList, Droplets } from "lucide-react";
 import UserNav from "./UserNav";
 import { getTranslations, getLocale } from "next-intl/server";
@@ -315,60 +316,8 @@ export default async function AdminUserOverview({ params }: { params: Promise<{ 
         </div>
       )}
 
-      {/* ── Einschluss-Liste ── (ausgeblendet)
-      {pairs.length === 0 ? (
-        <div className="bg-white rounded-2xl border border-gray-100 py-20 text-center text-gray-400 text-sm">
-          {t("noEntries")}
-        </div>
-      ) : (
-        <div className="bg-white rounded-2xl border border-gray-100 overflow-hidden">
-          <div className="grid grid-cols-[80px_1fr_1fr] sm:grid-cols-[96px_1fr_1fr_auto] border-b border-gray-100 px-5 py-3 gap-4">
-            <span className="text-xs font-semibold uppercase tracking-wider text-gray-400">{td("photo")}</span>
-            <span className="text-xs font-semibold uppercase tracking-wider text-gray-400 flex items-center gap-1"><Lock size={11} />{td("lock")}</span>
-            <span className="text-xs font-semibold uppercase tracking-wider text-gray-400 flex items-center gap-1"><LockOpen size={11} />{td("opening")}</span>
-            <span className="hidden sm:block text-xs font-semibold uppercase tracking-wider text-gray-400">{tc("duration")}</span>
-          </div>
-          <div className="divide-y divide-gray-50">
-            {pairs.map(({ verschluss, oeffnen, active }) => {
-              const ps = photoStatus(verschluss);
-              const duration = oeffnen ? formatDuration(verschluss.startTime, oeffnen.startTime, dl) : null;
-              return (
-                <PairRow
-                  key={verschluss.id}
-                  verschluss={{
-                    id: verschluss.id,
-                    startTime: verschluss.startTime.toISOString(),
-                    imageUrl: verschluss.imageUrl,
-                    imageExifTime: verschluss.imageExifTime?.toISOString() ?? null,
-                    note: verschluss.note,
-                    kontrollCode: verschluss.kontrollCode,
-                    verifikationStatus: verschluss.verifikationStatus,
-                    oeffnenGrund: verschluss.oeffnenGrund,
-                  }}
-                  oeffnen={oeffnen ? {
-                    id: oeffnen.id,
-                    startTime: oeffnen.startTime.toISOString(),
-                    imageUrl: oeffnen.imageUrl,
-                    imageExifTime: oeffnen.imageExifTime?.toISOString() ?? null,
-                    note: oeffnen.note,
-                    kontrollCode: oeffnen.kontrollCode,
-                    verifikationStatus: oeffnen.verifikationStatus,
-                    oeffnenGrund: oeffnen.oeffnenGrund,
-                  } : null}
-                  active={active}
-                  duration={duration}
-                  photoStatus={ps}
-                />
-              );
-            })}
-          </div>
-          <div className="flex items-center gap-4 px-5 py-3 border-t border-gray-50 text-xs text-gray-400">
-            <span className="flex items-center gap-1.5"><span className="w-2 h-2 rounded-full bg-red-400 flex-shrink-0" /> {ts("noPhoto")}</span>
-            <span className="flex items-center gap-1.5"><span className="w-2 h-2 rounded-full bg-amber-400 flex-shrink-0" /> {td("exifDeviation")}</span>
-          </div>
-        </div>
-      )}
-      */}
+      {/* ── Session-Liste ── */}
+      <SessionList pairs={pairs} orgasmusEntries={orgasmusEntries} />
 
       {/* ── Kontrollen ── */}
       {kontrollItems.length > 0 && (
@@ -414,13 +363,13 @@ export default async function AdminUserOverview({ params }: { params: Promise<{ 
           </div>
           <div className="divide-y divide-gray-50">
             {orgasmusEntries.map((e) => (
-              <div key={e.id} className="px-5 py-3 hover:bg-gray-50/60 transition">
-                <div className="flex items-center gap-1 min-w-0">
+              <div key={e.id} className="px-5 py-3 flex items-start gap-3 hover:bg-gray-50/60 transition">
+                <div className="flex-1 min-w-0">
                   <p className="text-sm font-semibold text-gray-900 truncate">{formatDateTime(e.startTime, dl)}</p>
-                  <EntryActions id={e.id} editHref={`/dashboard/edit/${e.id}`} />
+                  <p className="text-xs text-rose-500 font-medium mt-0.5">{e.orgasmusArt}</p>
+                  {e.note && <p className="text-xs text-gray-400 italic mt-0.5">„{e.note}"</p>}
                 </div>
-                <p className="text-xs text-rose-500 font-medium mt-0.5">{e.orgasmusArt}</p>
-                {e.note && <p className="text-xs text-gray-400 italic mt-0.5">„{e.note}"</p>}
+                <EntryActions id={e.id} editHref={`/dashboard/edit/${e.id}`} />
               </div>
             ))}
           </div>

--- a/src/app/api/admin/users/[id]/route.ts
+++ b/src/app/api/admin/users/[id]/route.ts
@@ -30,6 +30,14 @@ export async function PATCH(
     return NextResponse.json({ id: user.id, email: user.email });
   }
 
+  if (body.reinigungErlaubt !== undefined || body.reinigungMaxMinuten !== undefined) {
+    const data: { reinigungErlaubt?: boolean; reinigungMaxMinuten?: number } = {};
+    if (body.reinigungErlaubt !== undefined) data.reinigungErlaubt = Boolean(body.reinigungErlaubt);
+    if (body.reinigungMaxMinuten !== undefined) data.reinigungMaxMinuten = Math.max(1, Math.min(120, Number(body.reinigungMaxMinuten) || 15));
+    await prisma.user.update({ where: { id }, data });
+    return NextResponse.json({ ok: true });
+  }
+
   if (!["admin", "user"].includes(body.role)) {
     return NextResponse.json({ error: "Invalid role" }, { status: 400 });
   }

--- a/src/app/api/settings/reinigung/route.ts
+++ b/src/app/api/settings/reinigung/route.ts
@@ -1,0 +1,17 @@
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { NextResponse } from "next/server";
+
+export async function PATCH(req: Request) {
+  const session = await auth();
+  if (!session?.user?.id) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const { reinigungErlaubt, reinigungMaxMinuten } = await req.json();
+  await prisma.user.update({
+    where: { id: session.user.id },
+    data: {
+      reinigungErlaubt: Boolean(reinigungErlaubt),
+      reinigungMaxMinuten: Math.max(1, Math.min(120, Number(reinigungMaxMinuten) || 15)),
+    },
+  });
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/dashboard/LaufendeSessionCard.tsx
+++ b/src/app/dashboard/LaufendeSessionCard.tsx
@@ -1,4 +1,4 @@
-import { Lock, CheckCircle2, Droplets } from "lucide-react";
+import { Lock, LockOpen, CheckCircle2, Droplets } from "lucide-react";
 import { formatHours, formatDateTime, formatDate, formatTime, hasExifMismatch, toDateLocale } from "@/lib/utils";
 import { getTranslations, getLocale } from "next-intl/server";
 import { getKombinierterPill } from "@/lib/kontrollePills";
@@ -6,7 +6,7 @@ import SessionDurationBadge from "./SessionDurationBadge";
 import SessionEventRow from "./SessionEventRow";
 
 export interface SessionEvent {
-  type: "verschluss" | "kontrolle" | "orgasmus";
+  type: "verschluss" | "kontrolle" | "orgasmus" | "reinigung";
   time: Date;
   imageUrl: string | null;
   imageExifTime: Date | null;
@@ -18,6 +18,7 @@ export interface SessionEvent {
   kontrolleAnforderungStatus?: string | null;
   kontrolleVerifikationStatus?: string | null;
   orgasmusArt?: string | null;
+  pauseDurationStr?: string | null;
 }
 
 interface Props {
@@ -149,6 +150,7 @@ export default async function LaufendeSessionCard({
           const icon =
             ev.type === "verschluss" ? <Lock size={18} className="text-emerald-500" /> :
             ev.type === "kontrolle" ? <CheckCircle2 size={18} className="text-orange-400" /> :
+            ev.type === "reinigung" ? <LockOpen size={18} className="text-sky-400" /> :
             <Droplets size={18} className="text-rose-400" />;
 
           return (
@@ -173,6 +175,7 @@ export default async function LaufendeSessionCard({
                 kombiniertePillLabel: kombiniertePill?.label ?? null,
                 kombiniertePillCls: kombiniertePill?.cls ?? null,
                 orgasmusArt: ev.orgasmusArt ?? null,
+                pauseDurationStr: ev.pauseDurationStr ?? null,
               }}
             />
           );

--- a/src/app/dashboard/LaufendeSessionCard.tsx
+++ b/src/app/dashboard/LaufendeSessionCard.tsx
@@ -22,6 +22,7 @@ export interface SessionEvent {
 
 interface Props {
   sessionStart: Date;
+  interruptionPausedMs?: number;
   now: Date;
   events: SessionEvent[];
   sperrzeitEndetAt: Date | null;
@@ -53,6 +54,7 @@ function ProgressBar({ actual, target, label }: { actual: number; target: number
 
 export default async function LaufendeSessionCard({
   sessionStart,
+  interruptionPausedMs = 0,
   events,
   sperrzeitEndetAt,
   sperrzeitNachricht,
@@ -90,7 +92,7 @@ export default async function LaufendeSessionCard({
               <div className="flex items-baseline gap-1.5 mt-1">
                 <span className="text-xs font-semibold uppercase tracking-widest opacity-60">{tCommon("duration")}:</span>
                 <span className="text-lg font-bold tabular-nums">
-                  <SessionDurationBadge since={sessionStart.toISOString()} />
+                  <SessionDurationBadge since={sessionStart.toISOString()} pausedMs={interruptionPausedMs} />
                 </span>
               </div>
             </div>
@@ -103,7 +105,7 @@ export default async function LaufendeSessionCard({
               <div className="text-right flex-shrink-0">
                 <p className="text-xs font-semibold uppercase tracking-widest opacity-60 mb-0.5">{tCommon("duration")}</p>
                 <p className="text-2xl font-bold tabular-nums leading-tight">
-                  <SessionDurationBadge since={sessionStart.toISOString()} />
+                  <SessionDurationBadge since={sessionStart.toISOString()} pausedMs={interruptionPausedMs} />
                 </p>
               </div>
             </div>

--- a/src/app/dashboard/SessionDurationBadge.tsx
+++ b/src/app/dashboard/SessionDurationBadge.tsx
@@ -3,8 +3,8 @@
 import { useEffect, useState } from "react";
 import { useLocale } from "next-intl";
 
-function elapsed(from: Date, locale: string): string {
-  const ms = Date.now() - from.getTime();
+function elapsed(from: Date, locale: string, pausedMs = 0): string {
+  const ms = Math.max(0, Date.now() - from.getTime() - pausedMs);
   const totalMinutes = Math.floor(ms / 60000);
   const days = Math.floor(totalMinutes / 1440);
   const hours = Math.floor((totalMinutes % 1440) / 60);
@@ -17,12 +17,12 @@ function elapsed(from: Date, locale: string): string {
   return parts.join(" ");
 }
 
-export default function SessionDurationBadge({ since }: { since: string }) {
+export default function SessionDurationBadge({ since, pausedMs = 0 }: { since: string; pausedMs?: number }) {
   const locale = useLocale();
   const [, setTick] = useState(0);
   useEffect(() => {
     const id = setInterval(() => setTick((n) => n + 1), 60000);
     return () => clearInterval(id);
   }, []);
-  return <span suppressHydrationWarning>{elapsed(new Date(since), locale)}</span>;
+  return <span suppressHydrationWarning>{elapsed(new Date(since), locale, pausedMs)}</span>;
 }

--- a/src/app/dashboard/SessionEventRow.tsx
+++ b/src/app/dashboard/SessionEventRow.tsx
@@ -1,13 +1,13 @@
 "use client";
 
 import { useState, useRef, useEffect } from "react";
-import { X, Lock, CheckCircle2, Droplets, ImageOff, MoreVertical, Camera, AlertTriangle, AlertCircle } from "lucide-react";
+import { X, Lock, LockOpen, CheckCircle2, Droplets, ImageOff, MoreVertical, Camera, AlertTriangle, AlertCircle } from "lucide-react";
 import { useTranslations } from "next-intl";
 import Link from "next/link";
 import EntryActions from "./EntryActions";
 
 export interface SessionEventData {
-  type: "verschluss" | "kontrolle" | "orgasmus";
+  type: "verschluss" | "kontrolle" | "orgasmus" | "reinigung";
   dateStr: string;
   timeStr: string;
   imageUrl: string | null;
@@ -22,6 +22,7 @@ export interface SessionEventData {
   kombiniertePillLabel: string | null;
   kombiniertePillCls: string | null;
   orgasmusArt: string | null;
+  pauseDurationStr?: string | null;
 }
 
 function PinchZoomImage({ src, onError }: { src: string; onError: () => void }) {
@@ -123,6 +124,37 @@ export default function SessionEventRow({ ev, icon }: { ev: SessionEventData; ic
   const [open, setOpen] = useState(false);
   const [imgError, setImgError] = useState(false);
   const hasImage = !!ev.imageUrl && !imgError;
+
+  // Reinigung → compact inline row (no modal)
+  if (ev.type === "reinigung") {
+    return (
+      <div className="w-full flex items-center gap-4 px-5 py-3 text-left">
+        <div className="shrink-0 w-14 h-14 sm:w-16 sm:h-16 rounded-xl bg-sky-50 flex items-center justify-center">
+          <LockOpen size={18} className="text-sky-400" />
+        </div>
+        <div className="flex-1 min-w-0 pt-0.5">
+          <div className="flex items-start justify-between gap-2">
+            <div>
+              <div className="mb-0.5 sm:hidden">
+                <span className="inline-flex items-center gap-1 text-xs font-semibold text-sky-600 bg-sky-50 border border-sky-200 px-2 py-0.5 rounded-full">
+                  <LockOpen size={10} />{t("sessionReinigung")}
+                </span>
+              </div>
+              <span className="block text-sm font-semibold text-gray-900 tabular-nums">{ev.dateStr}</span>
+              <span className="block text-xs text-gray-400 tabular-nums">{ev.timeStr}</span>
+            </div>
+            <span className="hidden sm:inline-flex items-center gap-1 text-xs font-semibold text-sky-600 bg-sky-50 border border-sky-200 px-2 py-0.5 rounded-full shrink-0">
+              <LockOpen size={10} />{t("sessionReinigung")}
+            </span>
+          </div>
+          {ev.pauseDurationStr && (
+            <p className="text-xs text-sky-500 mt-0.5">{ev.pauseDurationStr}</p>
+          )}
+          {ev.note && <p className="text-xs text-gray-400 italic mt-0.5 truncate">„{ev.note}"</p>}
+        </div>
+      </div>
+    );
+  }
 
   const typePill = ev.type === "verschluss" ? (
     <span className="inline-flex items-center gap-1 text-xs font-semibold text-emerald-700 bg-emerald-50 border border-emerald-200 px-2 py-0.5 rounded-full">

--- a/src/app/dashboard/SessionList.tsx
+++ b/src/app/dashboard/SessionList.tsx
@@ -1,5 +1,5 @@
 import { getLocale } from "next-intl/server";
-import { toDateLocale, formatDuration, formatDate, formatTime, formatDateTime, hasExifMismatch, interruptionPauseMs } from "@/lib/utils";
+import { toDateLocale, formatDuration, formatDate, formatTime, formatDateTime, hasExifMismatch, interruptionPauseMs, type ReinigungSettings } from "@/lib/utils";
 import { getKombinierterPill } from "@/lib/kontrollePills";
 import SessionListClient, { SessionListData } from "./SessionListClient";
 
@@ -114,6 +114,25 @@ export default async function SessionList({ pairs, orgasmusEntries }: Props) {
         kombiniertePillLabel: null,
         kombiniertePillCls: null,
         orgasmusArt: e.orgasmusArt,
+      })),
+      ...(pair.interruptions ?? []).map((intr) => ({
+        type: "reinigung" as const,
+        time: intr.oeffnen.startTime,
+        dateStr: formatDate(intr.oeffnen.startTime, dl),
+        timeStr: formatTime(intr.oeffnen.startTime, dl),
+        imageUrl: null,
+        exifStr: null,
+        note: intr.oeffnen.note,
+        entryId: null,
+        captureHref: null,
+        deadlineStr: null,
+        isOverdue: false,
+        kontrolleCode: null,
+        kontrolleKommentar: null,
+        kombiniertePillLabel: null,
+        kombiniertePillCls: null,
+        orgasmusArt: null,
+        pauseDurationStr: formatDuration(intr.oeffnen.startTime, intr.verschluss.startTime, dl),
       })),
     ].sort((a, b) => a.time.getTime() - b.time.getTime());
 

--- a/src/app/dashboard/SessionList.tsx
+++ b/src/app/dashboard/SessionList.tsx
@@ -1,5 +1,5 @@
 import { getLocale } from "next-intl/server";
-import { toDateLocale, formatDuration, formatDate, formatTime, formatDateTime, hasExifMismatch } from "@/lib/utils";
+import { toDateLocale, formatDuration, formatDate, formatTime, formatDateTime, hasExifMismatch, interruptionPauseMs } from "@/lib/utils";
 import { getKombinierterPill } from "@/lib/kontrollePills";
 import SessionListClient, { SessionListData } from "./SessionListClient";
 
@@ -30,6 +30,7 @@ interface Pair {
   oeffnen: Entry | null;
   active: boolean;
   kontrollen: KontrolleItem[];
+  interruptions?: { oeffnen: Entry; verschluss: Entry }[];
 }
 
 interface Props {
@@ -46,7 +47,10 @@ export default async function SessionList({ pairs, orgasmusEntries }: Props) {
 
     const dateStr = formatDate(verschluss.startTime, dl);
     const timeStr = formatTime(verschluss.startTime, dl);
-    const durationStr = oeffnen ? formatDuration(verschluss.startTime, oeffnen.startTime, dl) : null;
+    const pauseMs = interruptionPauseMs(pair.interruptions ?? []);
+    const durationStr = oeffnen
+      ? formatDuration(new Date(verschluss.startTime.getTime()), new Date(oeffnen.startTime.getTime() - pauseMs), dl)
+      : null;
 
     const sessionOrgasmen = orgasmusEntries.filter(
       (e) => e.startTime >= verschluss.startTime && (oeffnen === null || e.startTime < oeffnen.startTime)

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -2,9 +2,10 @@ import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import {
   formatDuration, formatDateTime, formatDate, formatHours,
-  wearingHoursInRange, buildPairs, photoStatus,
+  wearingHoursInRange, buildPairs, interruptionPauseMs, photoStatus,
   mapAnforderungStatus, mapVerifikationStatus,
   getMidnightToday, getWeekStart, getMonthStart, toDateLocale,
+  type ReinigungSettings,
 } from "@/lib/utils";
 import { getActiveVorgabe } from "@/lib/queries";
 import { ANFORDERUNG_PILLS, getKombinierterPill } from "@/lib/kontrollePills";
@@ -49,6 +50,7 @@ type Pair = {
   oeffnen: Entry | null;
   active: boolean;
   kontrollen: KontrolleItem[];
+  interruptions: { oeffnen: Entry; verschluss: Entry }[];
 };
 
 
@@ -71,7 +73,7 @@ export default async function DashboardPage() {
   };
   const dl = toDateLocale(await getLocale());
   const now = new Date();
-  const [entries, alleAnforderungen, activeVorgabe, offeneVerschlussAnf, activeSperrzeit] = await Promise.all([
+  const [entries, alleAnforderungen, activeVorgabe, offeneVerschlussAnf, activeSperrzeit, userSettings] = await Promise.all([
     prisma.entry.findMany({ where: { userId }, orderBy: { startTime: "desc" } }),
     prisma.kontrollAnforderung.findMany({ where: { userId }, orderBy: { createdAt: "desc" }, include: { entry: true } }),
     getActiveVorgabe(userId, now),
@@ -81,7 +83,13 @@ export default async function DashboardPage() {
     prisma.verschlussAnforderung.findFirst({
       where: { userId, art: "SPERRZEIT", withdrawnAt: null, endetAt: { gt: now } },
     }),
+    prisma.user.findUnique({ where: { id: userId }, select: { reinigungErlaubt: true, reinigungMaxMinuten: true } }),
   ]);
+
+  const reinigung: ReinigungSettings = {
+    erlaubt: userSettings?.reinigungErlaubt ?? false,
+    maxMinuten: userSettings?.reinigungMaxMinuten ?? 15,
+  };
 
   const offeneKontrolle = alleAnforderungen.find(k => !k.entryId && !k.withdrawnAt) ?? null;
 
@@ -128,11 +136,12 @@ export default async function DashboardPage() {
     ? { type: latest.type as "VERSCHLUSS" | "OEFFNEN", since: latest.startTime.toISOString() }
     : null;
 
-  const pairs = buildPairs(entries, kontrollItems);
+  const pairs = buildPairs(entries, kontrollItems, reinigung);
   const verschluesse = entries.filter((e) => e.type === "VERSCHLUSS");
   const completedPairs = pairs.filter((p) => p.oeffnen);
   const totalMs = completedPairs.reduce(
-    (s, p) => s + p.oeffnen!.startTime.getTime() - p.verschluss.startTime.getTime(), 0
+    (s, p) => s + (p.oeffnen!.startTime.getTime() - p.verschluss.startTime.getTime()) - interruptionPauseMs(p.interruptions),
+    0
   );
   const totalFormatted = completedPairs.length ? formatDuration(new Date(0), new Date(totalMs), dl) : "–";
   const orgasmusEntries = entries
@@ -184,9 +193,9 @@ export default async function DashboardPage() {
   const nowMidnight = getMidnightToday(now);
   const weekStart = getWeekStart(now);
   const monthStart = getMonthStart(now);
-  const tagH = activePair ? wearingHoursInRange(entries, nowMidnight, now) : 0;
-  const wocheH = activePair ? wearingHoursInRange(entries, weekStart, now) : 0;
-  const monatH = activePair ? wearingHoursInRange(entries, monthStart, now) : 0;
+  const tagH = activePair ? wearingHoursInRange(entries, nowMidnight, now, reinigung) : 0;
+  const wocheH = activePair ? wearingHoursInRange(entries, weekStart, now, reinigung) : 0;
+  const monatH = activePair ? wearingHoursInRange(entries, monthStart, now, reinigung) : 0;
 
   return (
     <>
@@ -197,6 +206,7 @@ export default async function DashboardPage() {
         {activePair ? (
           <LaufendeSessionCard
             sessionStart={activePair.verschluss.startTime}
+            interruptionPausedMs={interruptionPauseMs(activePair.interruptions)}
             now={now}
             events={sessionEvents}
             sperrzeitEndetAt={activeSperrzeit?.endetAt ?? null}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -187,6 +187,15 @@ export default async function DashboardPage() {
             entryId: e.id,
             orgasmusArt: e.orgasmusArt,
           })),
+        ...activePair.interruptions.map((intr) => ({
+          type: "reinigung" as const,
+          time: intr.oeffnen.startTime,
+          imageUrl: null,
+          imageExifTime: null,
+          note: intr.oeffnen.note,
+          entryId: null,
+          pauseDurationStr: formatDuration(intr.oeffnen.startTime, intr.verschluss.startTime, dl),
+        })),
       ].sort((a, b) => a.time.getTime() - b.time.getTime())
     : [];
 

--- a/src/app/dashboard/settings/SettingsForm.tsx
+++ b/src/app/dashboard/settings/SettingsForm.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { useState } from "react";
+import { signOut } from "next-auth/react";
+import { useTranslations, useLocale } from "next-intl";
+import { useRouter } from "next/navigation";
+
+const inputCls =
+  "w-full border border-gray-200 rounded-xl px-4 py-3 text-base text-gray-900 focus:outline-none focus:ring-2 focus:ring-indigo-400 bg-gray-50";
+
+interface Props {
+  reinigungErlaubt: boolean;
+  reinigungMaxMinuten: number;
+}
+
+export default function SettingsForm({ reinigungErlaubt, reinigungMaxMinuten }: Props) {
+  const t = useTranslations("settings");
+  const locale = useLocale();
+  const router = useRouter();
+
+  function setLocale(value: string) {
+    document.cookie = `locale=${value}; path=/; max-age=31536000; SameSite=Lax`;
+    router.refresh();
+  }
+
+  const [current, setCurrent] = useState("");
+  const [next, setNext] = useState("");
+  const [confirm, setConfirm] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  const [reinigungChecked, setReinigungChecked] = useState(reinigungErlaubt);
+  const [reinigungMin, setReinigungMin] = useState(reinigungMaxMinuten);
+  const [reinigungSaved, setReinigungSaved] = useState(false);
+  const [reinigungLoading, setReinigungLoading] = useState(false);
+
+  async function handlePassword(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    if (next !== confirm) { setError(t("passwordMismatch")); return; }
+    setLoading(true);
+    const res = await fetch("/api/settings/password", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ currentPassword: current, newPassword: next }),
+    });
+    setLoading(false);
+    if (res.ok) {
+      setSuccess(true);
+      setCurrent(""); setNext(""); setConfirm("");
+    } else {
+      const data = await res.json();
+      setError(data.error ?? t("saveBtn"));
+    }
+  }
+
+  async function handleReinigung(e: React.FormEvent) {
+    e.preventDefault();
+    setReinigungLoading(true);
+    await fetch("/api/settings/reinigung", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ reinigungErlaubt: reinigungChecked, reinigungMaxMinuten: reinigungMin }),
+    });
+    setReinigungLoading(false);
+    setReinigungSaved(true);
+    setTimeout(() => setReinigungSaved(false), 2500);
+    router.refresh();
+  }
+
+  return (
+    <main className="flex-1 w-full max-w-5xl px-6 py-8"><div className="max-w-lg">
+      <h1 className="text-xl font-bold text-gray-900 mb-6">{t("title")}</h1>
+
+      {/* Language */}
+      <div className="bg-white rounded-2xl border border-gray-100 p-6 mb-4">
+        <h2 className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-4">{t("language")}</h2>
+        <select value={locale} onChange={(e) => setLocale(e.target.value)} className={inputCls}>
+          <option value="de">Deutsch</option>
+          <option value="en">English</option>
+        </select>
+      </div>
+
+      {/* Reinigungsunterbrechung */}
+      <div className="bg-white rounded-2xl border border-gray-100 p-6 mb-4">
+        <h2 className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-4">{t("reinigungTitle")}</h2>
+        <form onSubmit={handleReinigung} className="flex flex-col gap-4">
+          <label className="flex items-center gap-3 cursor-pointer select-none">
+            <input
+              type="checkbox"
+              checked={reinigungChecked}
+              onChange={(e) => setReinigungChecked(e.target.checked)}
+              className="w-5 h-5 rounded accent-indigo-600"
+            />
+            <span className="text-sm text-gray-700">{t("reinigungErlaubt")}</span>
+          </label>
+          {reinigungChecked && (
+            <div className="flex flex-col gap-1.5">
+              <label className="text-xs font-semibold text-gray-500 uppercase tracking-wider">{t("reinigungMaxMinuten")}</label>
+              <div className="flex items-center gap-2">
+                <input
+                  type="number"
+                  min={1}
+                  max={120}
+                  value={reinigungMin}
+                  onChange={(e) => setReinigungMin(Number(e.target.value))}
+                  className="w-24 border border-gray-200 rounded-xl px-4 py-3 text-base text-gray-900 focus:outline-none focus:ring-2 focus:ring-indigo-400 bg-gray-50"
+                />
+                <span className="text-sm text-gray-500">{t("minutes")}</span>
+              </div>
+            </div>
+          )}
+          <div className="flex items-center gap-3">
+            <button
+              type="submit"
+              disabled={reinigungLoading}
+              className="bg-indigo-600 text-white font-semibold px-5 py-2.5 rounded-xl hover:bg-indigo-500 active:scale-95 transition-all disabled:opacity-50 text-sm"
+            >
+              {reinigungLoading ? t("saving") : t("saveBtn")}
+            </button>
+            {reinigungSaved && <span className="text-sm text-emerald-600">{t("saved")}</span>}
+          </div>
+        </form>
+      </div>
+
+      {/* Password */}
+      <div className="bg-white rounded-2xl border border-gray-100 p-6">
+        <h2 className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-5">{t("changePassword")}</h2>
+        {success ? (
+          <p className="text-sm text-emerald-700 bg-emerald-50 rounded-xl px-4 py-3">{t("passwordChanged")}</p>
+        ) : (
+          <form onSubmit={handlePassword} className="flex flex-col gap-4">
+            <div className="flex flex-col gap-1.5">
+              <label className="text-xs font-semibold text-gray-500 uppercase tracking-wider">{t("currentPassword")}</label>
+              <input type="password" value={current} onChange={(e) => setCurrent(e.target.value)} required autoComplete="current-password" className={inputCls} />
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <label className="text-xs font-semibold text-gray-500 uppercase tracking-wider">{t("newPassword")}</label>
+              <input type="password" value={next} onChange={(e) => setNext(e.target.value)} required minLength={4} autoComplete="new-password" className={inputCls} />
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <label className="text-xs font-semibold text-gray-500 uppercase tracking-wider">{t("confirmPassword")}</label>
+              <input type="password" value={confirm} onChange={(e) => setConfirm(e.target.value)} required autoComplete="new-password" className={inputCls} />
+            </div>
+            {error && <p className="text-sm text-red-600 bg-red-50 border border-red-200 rounded-xl px-4 py-3">{error}</p>}
+            <button type="submit" disabled={loading} className="w-full bg-indigo-600 text-white font-semibold py-3 rounded-xl hover:bg-indigo-500 active:scale-95 transition-all disabled:opacity-50">
+              {loading ? t("saving") : t("saveBtn")}
+            </button>
+          </form>
+        )}
+      </div>
+
+      <div className="mt-4">
+        <button
+          onClick={() => { if (window.confirm(t("signOutConfirm"))) signOut({ callbackUrl: "/login" }); }}
+          className="w-full text-sm font-semibold text-white bg-red-500 hover:bg-red-600 rounded-2xl py-4 active:scale-[0.98] transition-all"
+        >
+          {t("signOut")}
+        </button>
+      </div>
+    </div></main>
+  );
+}

--- a/src/app/dashboard/settings/SettingsForm.tsx
+++ b/src/app/dashboard/settings/SettingsForm.tsx
@@ -8,12 +8,7 @@ import { useRouter } from "next/navigation";
 const inputCls =
   "w-full border border-gray-200 rounded-xl px-4 py-3 text-base text-gray-900 focus:outline-none focus:ring-2 focus:ring-indigo-400 bg-gray-50";
 
-interface Props {
-  reinigungErlaubt: boolean;
-  reinigungMaxMinuten: number;
-}
-
-export default function SettingsForm({ reinigungErlaubt, reinigungMaxMinuten }: Props) {
+export default function SettingsForm() {
   const t = useTranslations("settings");
   const locale = useLocale();
   const router = useRouter();
@@ -30,10 +25,6 @@ export default function SettingsForm({ reinigungErlaubt, reinigungMaxMinuten }: 
   const [success, setSuccess] = useState(false);
   const [loading, setLoading] = useState(false);
 
-  const [reinigungChecked, setReinigungChecked] = useState(reinigungErlaubt);
-  const [reinigungMin, setReinigungMin] = useState(reinigungMaxMinuten);
-  const [reinigungSaved, setReinigungSaved] = useState(false);
-  const [reinigungLoading, setReinigungLoading] = useState(false);
 
   async function handlePassword(e: React.FormEvent) {
     e.preventDefault();
@@ -55,20 +46,6 @@ export default function SettingsForm({ reinigungErlaubt, reinigungMaxMinuten }: 
     }
   }
 
-  async function handleReinigung(e: React.FormEvent) {
-    e.preventDefault();
-    setReinigungLoading(true);
-    await fetch("/api/settings/reinigung", {
-      method: "PATCH",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ reinigungErlaubt: reinigungChecked, reinigungMaxMinuten: reinigungMin }),
-    });
-    setReinigungLoading(false);
-    setReinigungSaved(true);
-    setTimeout(() => setReinigungSaved(false), 2500);
-    router.refresh();
-  }
-
   return (
     <main className="flex-1 w-full max-w-5xl px-6 py-8"><div className="max-w-lg">
       <h1 className="text-xl font-bold text-gray-900 mb-6">{t("title")}</h1>
@@ -80,48 +57,6 @@ export default function SettingsForm({ reinigungErlaubt, reinigungMaxMinuten }: 
           <option value="de">Deutsch</option>
           <option value="en">English</option>
         </select>
-      </div>
-
-      {/* Reinigungsunterbrechung */}
-      <div className="bg-white rounded-2xl border border-gray-100 p-6 mb-4">
-        <h2 className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-4">{t("reinigungTitle")}</h2>
-        <form onSubmit={handleReinigung} className="flex flex-col gap-4">
-          <label className="flex items-center gap-3 cursor-pointer select-none">
-            <input
-              type="checkbox"
-              checked={reinigungChecked}
-              onChange={(e) => setReinigungChecked(e.target.checked)}
-              className="w-5 h-5 rounded accent-indigo-600"
-            />
-            <span className="text-sm text-gray-700">{t("reinigungErlaubt")}</span>
-          </label>
-          {reinigungChecked && (
-            <div className="flex flex-col gap-1.5">
-              <label className="text-xs font-semibold text-gray-500 uppercase tracking-wider">{t("reinigungMaxMinuten")}</label>
-              <div className="flex items-center gap-2">
-                <input
-                  type="number"
-                  min={1}
-                  max={120}
-                  value={reinigungMin}
-                  onChange={(e) => setReinigungMin(Number(e.target.value))}
-                  className="w-24 border border-gray-200 rounded-xl px-4 py-3 text-base text-gray-900 focus:outline-none focus:ring-2 focus:ring-indigo-400 bg-gray-50"
-                />
-                <span className="text-sm text-gray-500">{t("minutes")}</span>
-              </div>
-            </div>
-          )}
-          <div className="flex items-center gap-3">
-            <button
-              type="submit"
-              disabled={reinigungLoading}
-              className="bg-indigo-600 text-white font-semibold px-5 py-2.5 rounded-xl hover:bg-indigo-500 active:scale-95 transition-all disabled:opacity-50 text-sm"
-            >
-              {reinigungLoading ? t("saving") : t("saveBtn")}
-            </button>
-            {reinigungSaved && <span className="text-sm text-emerald-600">{t("saved")}</span>}
-          </div>
-        </form>
       </div>
 
       {/* Password */}

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -1,18 +1,5 @@
-import { auth } from "@/lib/auth";
-import { prisma } from "@/lib/prisma";
 import SettingsForm from "./SettingsForm";
 
-export default async function SettingsPage() {
-  const session = await auth();
-  const user = await prisma.user.findUnique({
-    where: { id: session!.user.id },
-    select: { reinigungErlaubt: true, reinigungMaxMinuten: true },
-  });
-
-  return (
-    <SettingsForm
-      reinigungErlaubt={user?.reinigungErlaubt ?? false}
-      reinigungMaxMinuten={user?.reinigungMaxMinuten ?? 15}
-    />
-  );
+export default function SettingsPage() {
+  return <SettingsForm />;
 }

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -1,134 +1,18 @@
-"use client";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import SettingsForm from "./SettingsForm";
 
-import { useState } from "react";
-import { signOut } from "next-auth/react";
-import { useTranslations, useLocale } from "next-intl";
-import { useRouter } from "next/navigation";
-
-const inputCls =
-  "w-full border border-gray-200 rounded-xl px-4 py-3 text-base text-gray-900 focus:outline-none focus:ring-2 focus:ring-indigo-400 bg-gray-50";
-
-export default function SettingsPage() {
-  const t = useTranslations("settings");
-  const locale = useLocale();
-  const router = useRouter();
-
-  function setLocale(value: string) {
-    document.cookie = `locale=${value}; path=/; max-age=31536000; SameSite=Lax`;
-    router.refresh();
-  }
-  const [current, setCurrent] = useState("");
-  const [next, setNext] = useState("");
-  const [confirm, setConfirm] = useState("");
-  const [error, setError] = useState<string | null>(null);
-  const [success, setSuccess] = useState(false);
-  const [loading, setLoading] = useState(false);
-
-  async function handleSubmit(e: React.FormEvent) {
-    e.preventDefault();
-    setError(null);
-    if (next !== confirm) {
-      setError(t("passwordMismatch"));
-      return;
-    }
-    setLoading(true);
-    const res = await fetch("/api/settings/password", {
-      method: "PATCH",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ currentPassword: current, newPassword: next }),
-    });
-    setLoading(false);
-    if (res.ok) {
-      setSuccess(true);
-      setCurrent(""); setNext(""); setConfirm("");
-    } else {
-      const data = await res.json();
-      setError(data.error ?? t("saveBtn"));
-    }
-  }
+export default async function SettingsPage() {
+  const session = await auth();
+  const user = await prisma.user.findUnique({
+    where: { id: session!.user.id },
+    select: { reinigungErlaubt: true, reinigungMaxMinuten: true },
+  });
 
   return (
-    <main className="flex-1 w-full max-w-5xl px-6 py-8"><div className="max-w-lg">
-      <h1 className="text-xl font-bold text-gray-900 mb-6">{t("title")}</h1>
-
-      <div className="bg-white rounded-2xl border border-gray-100 p-6 mb-4">
-        <h2 className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-4">{t("language")}</h2>
-        <select
-          value={locale}
-          onChange={(e) => setLocale(e.target.value)}
-          className={inputCls}
-        >
-          <option value="de">Deutsch</option>
-          <option value="en">English</option>
-        </select>
-      </div>
-
-      <div className="bg-white rounded-2xl border border-gray-100 p-6">
-        <h2 className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-5">{t("changePassword")}</h2>
-
-        {success ? (
-          <p className="text-sm text-emerald-700 bg-emerald-50 rounded-xl px-4 py-3">
-            {t("passwordChanged")}
-          </p>
-        ) : (
-          <form onSubmit={handleSubmit} className="flex flex-col gap-4">
-            <div className="flex flex-col gap-1.5">
-              <label className="text-xs font-semibold text-gray-500 uppercase tracking-wider">{t("currentPassword")}</label>
-              <input
-                type="password"
-                value={current}
-                onChange={(e) => setCurrent(e.target.value)}
-                required
-                autoComplete="current-password"
-                className={inputCls}
-              />
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <label className="text-xs font-semibold text-gray-500 uppercase tracking-wider">{t("newPassword")}</label>
-              <input
-                type="password"
-                value={next}
-                onChange={(e) => setNext(e.target.value)}
-                required
-                minLength={4}
-                autoComplete="new-password"
-                className={inputCls}
-              />
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <label className="text-xs font-semibold text-gray-500 uppercase tracking-wider">{t("confirmPassword")}</label>
-              <input
-                type="password"
-                value={confirm}
-                onChange={(e) => setConfirm(e.target.value)}
-                required
-                autoComplete="new-password"
-                className={inputCls}
-              />
-            </div>
-            {error && (
-              <p className="text-sm text-red-600 bg-red-50 border border-red-200 rounded-xl px-4 py-3">{error}</p>
-            )}
-            <button
-              type="submit"
-              disabled={loading}
-              className="w-full bg-indigo-600 text-white font-semibold py-3 rounded-xl hover:bg-indigo-500 active:scale-95 transition-all disabled:opacity-50"
-            >
-              {loading ? t("saving") : t("saveBtn")}
-            </button>
-          </form>
-        )}
-      </div>
-
-      {/* Mobile: Abmelden */}
-      <div className="mt-4">
-        <button
-          onClick={() => { if (window.confirm(t("signOutConfirm"))) signOut({ callbackUrl: "/login" }); }}
-          className="w-full text-sm font-semibold text-white bg-red-500 hover:bg-red-600 rounded-2xl py-4 active:scale-[0.98] transition-all"
-        >
-          {t("signOut")}
-        </button>
-      </div>
-    </div></main>
+    <SettingsForm
+      reinigungErlaubt={user?.reinigungErlaubt ?? false}
+      reinigungMaxMinuten={user?.reinigungMaxMinuten ?? 15}
+    />
   );
 }

--- a/src/data/changelog.json
+++ b/src/data/changelog.json
@@ -1,5 +1,19 @@
 [
   {
+    "version": "1.7.1",
+    "date": "2026-03-24",
+    "changes": [
+      {
+        "type": "feat",
+        "text": "Admin / Benutzer-Übersicht: Session-Liste (identisch mit /dashboard) wird unterhalb der Navigation angezeigt"
+      },
+      {
+        "type": "fix",
+        "text": "Admin / Benutzer-Übersicht: Orgasmus-Einträge zeigen Aktionsmenü rechtsbündig"
+      }
+    ]
+  },
+  {
     "version": "1.7.0",
     "date": "2026-03-22",
     "changes": [

--- a/src/data/changelog.json
+++ b/src/data/changelog.json
@@ -1,5 +1,23 @@
 [
   {
+    "version": "1.7.0",
+    "date": "2026-03-22",
+    "changes": [
+      {
+        "type": "feat",
+        "text": "Reinigungsunterbrechungen: Öffnung mit Grund «Reinigung» gefolgt von erneutem Verschluss innerhalb der konfigurierten Zeit gilt als Unterbrechung innerhalb der laufenden Session (kein Sessionende)"
+      },
+      {
+        "type": "feat",
+        "text": "Einstellungen: Checkbox «Reinigungsunterbrechung zulassen» und konfigurierbare maximale Dauer (in Minuten, Standard 15)"
+      },
+      {
+        "type": "feat",
+        "text": "Sessiondauer: Effektive Tragedauer (Reinigungspausen werden von Gesamtdauer abgezogen)"
+      }
+    ]
+  },
+  {
     "version": "1.6.2",
     "date": "2026-03-22",
     "changes": [

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -183,17 +183,12 @@ export function buildPairs<
     }
   }
 
-  // Handle open session (still wearing or in reinigung pause)
+  // Handle open session (still wearing or pending reinigung)
   if (pending) {
     if (pendingReinigung && reinigung?.erlaubt) {
-      const dt = (Date.now() - pendingReinigung.startTime.getTime()) / 60000;
-      if (dt > reinigung.maxMinuten) {
-        // Reinigung timed out – session ended at reinigung OEFFNEN
-        pairs.push({ verschluss: pending, oeffnen: pendingReinigung, active: false, kontrollen: [], interruptions: currentInterruptions });
-      } else {
-        // Still in valid reinigung window – treat as active
-        pairs.push({ verschluss: pending, oeffnen: null, active: true, kontrollen: [], interruptions: currentInterruptions });
-      }
+      // Device is currently open for cleaning – show session as ended at reinigung OEFFNEN.
+      // If user re-locks within maxMinuten, the next page load will merge it as an interruption.
+      pairs.push({ verschluss: pending, oeffnen: pendingReinigung, active: false, kontrollen: [], interruptions: currentInterruptions });
     } else {
       pairs.push({ verschluss: pending, oeffnen: null, active: true, kontrollen: [], interruptions: currentInterruptions });
     }
@@ -225,14 +220,15 @@ export function photoStatus(v: { imageUrl: string | null; imageExifTime: Date | 
   return "ok";
 }
 
-/** Berechnet Tragedauer in Stunden innerhalb eines Zeitraums.
- *  Reinigungspausen (OEFFNEN mit oeffnenGrund=REINIGUNG gefolgt von VERSCHLUSS
- *  innerhalb maxMinuten) werden von der Tragedauer abgezogen. */
+/** Berechnet effektive Tragedauer in Stunden innerhalb eines Zeitraums.
+ *  Jedes OEFFNEN (inkl. REINIGUNG) stoppt die Tragedauer – Pausen werden
+ *  dadurch automatisch ausgeschlossen. Das reinigung-Param wird für die
+ *  Signatur-Kompatibilität beibehalten, ändert aber die Berechnung nicht. */
 export function wearingHoursInRange(
   entries: { type: string; startTime: Date; oeffnenGrund?: string | null }[],
   from: Date,
   to: Date,
-  reinigung?: ReinigungSettings
+  _reinigung?: ReinigungSettings
 ): number {
   const sorted = [...entries]
     .filter((e) => e.type === "VERSCHLUSS" || e.type === "OEFFNEN")
@@ -240,69 +236,21 @@ export function wearingHoursInRange(
 
   let total = 0;
   let wearStart: Date | null = null;
-  let pendingReinigung: Date | null = null;
 
   for (const e of sorted) {
     if (e.type === "VERSCHLUSS") {
-      if (pendingReinigung && reinigung?.erlaubt) {
-        const dt = (e.startTime.getTime() - pendingReinigung.getTime()) / 60000;
-        if (dt <= reinigung.maxMinuten) {
-          // Valid interruption – subtract pause, continue wearing
-          const pauseS = Math.max(pendingReinigung.getTime(), from.getTime());
-          const pauseE = Math.min(e.startTime.getTime(), to.getTime());
-          if (pauseE > pauseS) total -= pauseE - pauseS;
-          pendingReinigung = null;
-        } else {
-          // Timeout – close wear at pendingReinigung, start new
-          const s = Math.max(wearStart!.getTime(), from.getTime());
-          const end = Math.min(pendingReinigung.getTime(), to.getTime());
-          if (end > s) total += end - s;
-          wearStart = e.startTime;
-          pendingReinigung = null;
-        }
-      } else {
-        wearStart = e.startTime;
-      }
+      wearStart = e.startTime;
     } else if (e.type === "OEFFNEN" && wearStart) {
-      if (reinigung?.erlaubt && e.oeffnenGrund === "REINIGUNG") {
-        pendingReinigung = e.startTime;
-        // Add wear up to this point (will subtract pause later if re-lock in time)
-        const s = Math.max(wearStart.getTime(), from.getTime());
-        const end = Math.min(e.startTime.getTime(), to.getTime());
-        if (end > s) total += end - s;
-        wearStart = null;
-      } else {
-        if (pendingReinigung) {
-          // Pending reinigung, then another regular open – close at pendingReinigung
-          const s = Math.max(wearStart.getTime(), from.getTime());
-          const end = Math.min(pendingReinigung.getTime(), to.getTime());
-          if (end > s) total += end - s;
-          wearStart = null;
-          pendingReinigung = null;
-        } else {
-          const s = Math.max(wearStart.getTime(), from.getTime());
-          const end = Math.min(e.startTime.getTime(), to.getTime());
-          if (end > s) total += end - s;
-          wearStart = null;
-        }
-      }
+      const s = Math.max(wearStart.getTime(), from.getTime());
+      const end = Math.min(e.startTime.getTime(), to.getTime());
+      if (end > s) total += end - s;
+      wearStart = null;
     }
   }
-
   if (wearStart) {
     const s = Math.max(wearStart.getTime(), from.getTime());
     const end = to.getTime();
     if (end > s) total += end - s;
-  } else if (pendingReinigung && reinigung?.erlaubt) {
-    // In reinigung pause at end of range – check timeout
-    const dt = (to.getTime() - pendingReinigung.getTime()) / 60000;
-    if (dt <= reinigung.maxMinuten) {
-      // Still within window – add pause time back (session is still active)
-      const s = Math.max(pendingReinigung.getTime(), from.getTime());
-      const end = to.getTime();
-      if (end > s) total += end - s;
-    }
-    // else: timed out – wear already accounted for up to pendingReinigung
   }
 
   return total / (1000 * 60 * 60);

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -118,31 +118,89 @@ export function mapVerifikationStatus(vs: string | null): VerifikationStatus {
 }
 
 
-/** Builds Verschluss/Oeffnen pairs with associated Kontrollen, newest first */
+export type ReinigungSettings = { erlaubt: boolean; maxMinuten: number };
+
+type PairResult<E, K> = {
+  verschluss: E;
+  oeffnen: E | null;
+  active: boolean;
+  kontrollen: K[];
+  interruptions: { oeffnen: E; verschluss: E }[];
+};
+
+/** Builds Verschluss/Oeffnen pairs with associated Kontrollen, newest first.
+ *  If reinigung settings are provided, OEFFNEN(REINIGUNG) followed by a new
+ *  VERSCHLUSS within maxMinuten are treated as interruptions (not session ends). */
 export function buildPairs<
-  E extends { id: string; type: string; startTime: Date },
+  E extends { id: string; type: string; startTime: Date; oeffnenGrund?: string | null },
   K extends { time: Date }
->(entries: E[], kontrollen: K[]): { verschluss: E; oeffnen: E | null; active: boolean; kontrollen: K[] }[] {
+>(entries: E[], kontrollen: K[], reinigung?: ReinigungSettings): PairResult<E, K>[] {
   const asc = [...entries]
     .filter((e) => e.type === "VERSCHLUSS" || e.type === "OEFFNEN")
     .sort((a, b) => a.startTime.getTime() - b.startTime.getTime());
 
-  const pairs: { verschluss: E; oeffnen: E | null; active: boolean; kontrollen: K[] }[] = [];
+  const pairs: PairResult<E, K>[] = [];
   let pending: E | null = null;
+  let pendingReinigung: E | null = null;
+  let currentInterruptions: { oeffnen: E; verschluss: E }[] = [];
 
   for (const e of asc) {
     if (e.type === "VERSCHLUSS") {
-      if (pending) pairs.push({ verschluss: pending, oeffnen: null, active: false, kontrollen: [] });
-      pending = e;
+      if (pendingReinigung && pending && reinigung?.erlaubt) {
+        const dt = (e.startTime.getTime() - pendingReinigung.startTime.getTime()) / 60000;
+        if (dt <= reinigung.maxMinuten) {
+          // Valid interruption – continue session
+          currentInterruptions.push({ oeffnen: pendingReinigung, verschluss: e });
+          pendingReinigung = null;
+        } else {
+          // Timeout – close session at reinigung OEFFNEN, start new session
+          pairs.push({ verschluss: pending, oeffnen: pendingReinigung, active: false, kontrollen: [], interruptions: currentInterruptions });
+          pendingReinigung = null;
+          currentInterruptions = [];
+          pending = e;
+        }
+      } else {
+        if (pending) pairs.push({ verschluss: pending, oeffnen: null, active: false, kontrollen: [], interruptions: currentInterruptions });
+        currentInterruptions = [];
+        pending = e;
+      }
     } else if (e.type === "OEFFNEN" && pending) {
-      pairs.push({ verschluss: pending, oeffnen: e, active: false, kontrollen: [] });
-      pending = null;
+      if (reinigung?.erlaubt && e.oeffnenGrund === "REINIGUNG") {
+        pendingReinigung = e;
+      } else {
+        if (pendingReinigung) {
+          // Pending reinigung never got a re-lock in time → close at reinigung OEFFNEN
+          pairs.push({ verschluss: pending, oeffnen: pendingReinigung, active: false, kontrollen: [], interruptions: currentInterruptions });
+          pendingReinigung = null;
+          currentInterruptions = [];
+          pending = null;
+        } else {
+          pairs.push({ verschluss: pending, oeffnen: e, active: false, kontrollen: [], interruptions: currentInterruptions });
+          currentInterruptions = [];
+          pending = null;
+        }
+      }
     }
   }
-  if (pending) pairs.push({ verschluss: pending, oeffnen: null, active: true, kontrollen: [] });
+
+  // Handle open session (still wearing or in reinigung pause)
+  if (pending) {
+    if (pendingReinigung && reinigung?.erlaubt) {
+      const dt = (Date.now() - pendingReinigung.startTime.getTime()) / 60000;
+      if (dt > reinigung.maxMinuten) {
+        // Reinigung timed out – session ended at reinigung OEFFNEN
+        pairs.push({ verschluss: pending, oeffnen: pendingReinigung, active: false, kontrollen: [], interruptions: currentInterruptions });
+      } else {
+        // Still in valid reinigung window – treat as active
+        pairs.push({ verschluss: pending, oeffnen: null, active: true, kontrollen: [], interruptions: currentInterruptions });
+      }
+    } else {
+      pairs.push({ verschluss: pending, oeffnen: null, active: true, kontrollen: [], interruptions: currentInterruptions });
+    }
+  }
 
   for (const k of kontrollen) {
-    const pair = pairs.reduce<{ verschluss: E; oeffnen: E | null; active: boolean; kontrollen: K[] } | null>((best, p) => {
+    const pair = pairs.reduce<PairResult<E, K> | null>((best, p) => {
       const start = p.verschluss.startTime.getTime();
       const end = p.oeffnen ? p.oeffnen.startTime.getTime() : Infinity;
       if (k.time.getTime() < start || k.time.getTime() > end) return best;
@@ -155,6 +213,11 @@ export function buildPairs<
   return pairs.reverse();
 }
 
+/** Total pause duration from interruptions in ms */
+export function interruptionPauseMs(interruptions: { oeffnen: { startTime: Date }; verschluss: { startTime: Date } }[]): number {
+  return interruptions.reduce((s, i) => s + i.verschluss.startTime.getTime() - i.oeffnen.startTime.getTime(), 0);
+}
+
 /** Returns photo verification status for an entry */
 export function photoStatus(v: { imageUrl: string | null; imageExifTime: Date | null; startTime: Date }): "no-photo" | "exif-mismatch" | "ok" {
   if (!v.imageUrl) return "no-photo";
@@ -162,11 +225,14 @@ export function photoStatus(v: { imageUrl: string | null; imageExifTime: Date | 
   return "ok";
 }
 
-/** Berechnet Tragedauer in Stunden innerhalb eines Zeitraums. */
+/** Berechnet Tragedauer in Stunden innerhalb eines Zeitraums.
+ *  Reinigungspausen (OEFFNEN mit oeffnenGrund=REINIGUNG gefolgt von VERSCHLUSS
+ *  innerhalb maxMinuten) werden von der Tragedauer abgezogen. */
 export function wearingHoursInRange(
-  entries: { type: string; startTime: Date }[],
+  entries: { type: string; startTime: Date; oeffnenGrund?: string | null }[],
   from: Date,
-  to: Date
+  to: Date,
+  reinigung?: ReinigungSettings
 ): number {
   const sorted = [...entries]
     .filter((e) => e.type === "VERSCHLUSS" || e.type === "OEFFNEN")
@@ -174,21 +240,69 @@ export function wearingHoursInRange(
 
   let total = 0;
   let wearStart: Date | null = null;
+  let pendingReinigung: Date | null = null;
 
   for (const e of sorted) {
     if (e.type === "VERSCHLUSS") {
-      wearStart = e.startTime;
+      if (pendingReinigung && reinigung?.erlaubt) {
+        const dt = (e.startTime.getTime() - pendingReinigung.getTime()) / 60000;
+        if (dt <= reinigung.maxMinuten) {
+          // Valid interruption – subtract pause, continue wearing
+          const pauseS = Math.max(pendingReinigung.getTime(), from.getTime());
+          const pauseE = Math.min(e.startTime.getTime(), to.getTime());
+          if (pauseE > pauseS) total -= pauseE - pauseS;
+          pendingReinigung = null;
+        } else {
+          // Timeout – close wear at pendingReinigung, start new
+          const s = Math.max(wearStart!.getTime(), from.getTime());
+          const end = Math.min(pendingReinigung.getTime(), to.getTime());
+          if (end > s) total += end - s;
+          wearStart = e.startTime;
+          pendingReinigung = null;
+        }
+      } else {
+        wearStart = e.startTime;
+      }
     } else if (e.type === "OEFFNEN" && wearStart) {
-      const s = Math.max(wearStart.getTime(), from.getTime());
-      const end = Math.min(e.startTime.getTime(), to.getTime());
-      if (end > s) total += end - s;
-      wearStart = null;
+      if (reinigung?.erlaubt && e.oeffnenGrund === "REINIGUNG") {
+        pendingReinigung = e.startTime;
+        // Add wear up to this point (will subtract pause later if re-lock in time)
+        const s = Math.max(wearStart.getTime(), from.getTime());
+        const end = Math.min(e.startTime.getTime(), to.getTime());
+        if (end > s) total += end - s;
+        wearStart = null;
+      } else {
+        if (pendingReinigung) {
+          // Pending reinigung, then another regular open – close at pendingReinigung
+          const s = Math.max(wearStart.getTime(), from.getTime());
+          const end = Math.min(pendingReinigung.getTime(), to.getTime());
+          if (end > s) total += end - s;
+          wearStart = null;
+          pendingReinigung = null;
+        } else {
+          const s = Math.max(wearStart.getTime(), from.getTime());
+          const end = Math.min(e.startTime.getTime(), to.getTime());
+          if (end > s) total += end - s;
+          wearStart = null;
+        }
+      }
     }
   }
+
   if (wearStart) {
     const s = Math.max(wearStart.getTime(), from.getTime());
     const end = to.getTime();
     if (end > s) total += end - s;
+  } else if (pendingReinigung && reinigung?.erlaubt) {
+    // In reinigung pause at end of range – check timeout
+    const dt = (to.getTime() - pendingReinigung.getTime()) / 60000;
+    if (dt <= reinigung.maxMinuten) {
+      // Still within window – add pause time back (session is still active)
+      const s = Math.max(pendingReinigung.getTime(), from.getTime());
+      const end = to.getTime();
+      if (end > s) total += end - s;
+    }
+    // else: timed out – wear already accounted for up to pendingReinigung
   }
 
   return total / (1000 * 60 * 60);


### PR DESCRIPTION
## Summary

- Öffnung mit Grund «Reinigung» + erneuter Verschluss innerhalb X Minuten = Unterbrechung innerhalb der laufenden Session (kein Sessionende)
- Effektive Tragedauer: Reinigungspausen werden von Gesamtdauer abgezogen
- User-Einstellungen: Checkbox «Reinigungsunterbrechung zulassen» + konfigurierbare Maximaldauer (Standard 15 Min.)

## Changes

- **Prisma**: `reinigungErlaubt Boolean @default(false)` + `reinigungMaxMinuten Int @default(15)` auf User-Model, Migration erstellt
- **`src/lib/utils.ts`**: `ReinigungSettings`-Typ, `buildPairs` mit Interruption-Logik + `interruptions[]` im Return-Typ, `wearingHoursInRange` subtrahiert Reinigungspausen, neuer `interruptionPauseMs` helper
- **`PATCH /api/settings/reinigung`**: neuer API-Endpoint für User-Einstellungen
- **Settings-Seite**: Server-Wrapper + `SettingsForm` Client-Komponente mit Reinigung-Sektion
- **`SessionDurationBadge`**: neues `pausedMs`-Prop für effektive Dauer-Anzeige
- **`LaufendeSessionCard`**: `interruptionPausedMs`-Prop → wird an Badge weitergegeben
- **`SessionList`**: effektive Dauer (ohne Pausen) für abgeschlossene Sessions
- **`dashboard/page.tsx` + `admin/users/[id]/page.tsx`**: reinigung-Settings fetchen und an `buildPairs`/`wearingHoursInRange` weitergeben

## Test plan

- [ ] Settings-Seite: Checkbox + Minuten-Feld erscheint, speichert korrekt
- [ ] OEFFNEN(REINIGUNG) → VERSCHLUSS innerhalb Limit → gleiche Session, keine neue Pair
- [ ] OEFFNEN(REINIGUNG) → VERSCHLUSS nach Limit → Session endet an Reinigung
- [ ] Sessiondauer zeigt effektive Zeit (ohne Reinigungspausen)
- [ ] User mit reinigungErlaubt=false: keine Änderung am Verhalten
- [ ] `npm run build` grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)