### PR TITLE
feat: abbreviate session start date in ≥24h range

### DIFF
--- a/src/app/dashboard/SessionList.tsx
+++ b/src/app/dashboard/SessionList.tsx
@@ -62,9 +62,11 @@ export default async function SessionList({ pairs, orgasmusEntries }: Props) {
       const sMonth = verschluss.startTime.getMonth();
       const eMonth = oeffnen.startTime.getMonth();
       if (sYear === eYear && sMonth === eMonth) {
-        startAbbrevStr = verschluss.startTime.toLocaleDateString(dl, { day: "numeric", timeZone: APP_TZ });
+        const s = verschluss.startTime.toLocaleDateString(dl, { day: "numeric", timeZone: APP_TZ });
+        startAbbrevStr = s.endsWith(".") ? s : s + ".";
       } else if (sYear === eYear) {
-        startAbbrevStr = verschluss.startTime.toLocaleDateString(dl, { day: "numeric", month: "numeric", timeZone: APP_TZ });
+        const s = verschluss.startTime.toLocaleDateString(dl, { day: "numeric", month: "numeric", timeZone: APP_TZ });
+        startAbbrevStr = s.endsWith(".") ? s : s + ".";
       }
       // different year: null → use full dateStr
     }

--- a/src/app/dashboard/SessionList.tsx
+++ b/src/app/dashboard/SessionList.tsx
@@ -1,5 +1,5 @@
 import { getLocale, getTranslations } from "next-intl/server";
-import { toDateLocale, formatDuration, formatDate, formatTime, formatDateTime, hasExifMismatch, interruptionPauseMs, type ReinigungSettings } from "@/lib/utils";
+import { toDateLocale, formatDuration, formatDate, formatTime, formatDateTime, hasExifMismatch, interruptionPauseMs, APP_TZ, type ReinigungSettings } from "@/lib/utils";
 import { getKombinierterPill } from "@/lib/kontrollePills";
 import SessionListClient, { SessionListData } from "./SessionListClient";
 
@@ -54,6 +54,20 @@ export default async function SessionList({ pairs, orgasmusEntries }: Props) {
       ? formatDuration(new Date(0), new Date(durationMs), dl)
       : null;
     const durationUnder24h = durationMs !== null && durationMs < 24 * 60 * 60 * 1000;
+
+    let startAbbrevStr: string | null = null;
+    if (!durationUnder24h && oeffnen) {
+      const sYear = verschluss.startTime.getFullYear();
+      const eYear = oeffnen.startTime.getFullYear();
+      const sMonth = verschluss.startTime.getMonth();
+      const eMonth = oeffnen.startTime.getMonth();
+      if (sYear === eYear && sMonth === eMonth) {
+        startAbbrevStr = verschluss.startTime.toLocaleDateString(dl, { day: "numeric", timeZone: APP_TZ });
+      } else if (sYear === eYear) {
+        startAbbrevStr = verschluss.startTime.toLocaleDateString(dl, { day: "numeric", month: "numeric", timeZone: APP_TZ });
+      }
+      // different year: null → use full dateStr
+    }
 
     const sessionOrgasmen = orgasmusEntries.filter(
       (e) => e.startTime >= verschluss.startTime && (oeffnen === null || e.startTime < oeffnen.startTime)
@@ -148,6 +162,7 @@ export default async function SessionList({ pairs, orgasmusEntries }: Props) {
       active,
       thumbnailUrl: verschluss.imageUrl,
       events,
+      startAbbrevStr,
       oeffnen: oeffnen
         ? {
             dateStr: formatDate(oeffnen.startTime, dl),

--- a/src/app/dashboard/SessionListClient.tsx
+++ b/src/app/dashboard/SessionListClient.tsx
@@ -29,6 +29,7 @@ export interface SessionListData {
   thumbnailUrl: string | null;
   events: SessionEventData[];
   oeffnen: OeffnenFooter | null;
+  startAbbrevStr: string | null;
 }
 
 const PAGE_SIZE = 10;
@@ -70,7 +71,7 @@ export default function SessionListClient({ sessions }: { sessions: SessionListD
                   </>
                 ) : session.oeffnen ? (
                   <>
-                    <span className="block text-sm font-semibold text-gray-900 tabular-nums">{session.dateStr} – {session.oeffnen.dateStr}</span>
+                    <span className="block text-sm font-semibold text-gray-900 tabular-nums">{session.startAbbrevStr ?? session.dateStr} – {session.oeffnen.dateStr}</span>
                   </>
                 ) : (
                   <>


### PR DESCRIPTION
## Summary
- Same month: only show start day (e.g. `1.–5.3.2026`)
- Same year, different month: show day+month (e.g. `25.4.–5.5.2026`)
- Different year: both full dates unchanged

## Test plan
- [ ] Create session spanning same month → verify abbreviated start day
- [ ] Create session spanning different months, same year → verify day+month start
- [ ] Create session spanning different years → verify full dates shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)