### PR TITLE
fix: Security, Timezone & Performance (Code-Review)

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -11,45 +11,6 @@ import { Lock, LockOpen, UserPlus, Users, ShieldAlert } from "lucide-react";
 import { getTranslations, getLocale } from "next-intl/server";
 import { toDateLocale, formatDuration, APP_TZ } from "@/lib/utils";
 
-async function getUserStats(userId: string) {
-  const entries = await prisma.entry.findMany({
-    where: { userId },
-    orderBy: { startTime: "asc" },
-  });
-
-  const latest = [...entries]
-    .filter((e) => e.type === "VERSCHLUSS" || e.type === "OEFFNEN")
-    .sort((a, b) => b.startTime.getTime() - a.startTime.getTime())[0] ?? null;
-
-  const now = new Date();
-  const offeneKontrolle = await prisma.kontrollAnforderung.findFirst({
-    where: { userId, entryId: null, withdrawnAt: null },
-    orderBy: { createdAt: "desc" },
-  });
-  const offeneVerschlussAnforderung = await prisma.verschlussAnforderung.findFirst({
-    where: { userId, art: "ANFORDERUNG", fulfilledAt: null, withdrawnAt: null },
-  });
-  const activeSperrzeit = await prisma.verschlussAnforderung.findFirst({
-    where: { userId, art: "SPERRZEIT", withdrawnAt: null, OR: [{ endetAt: { gt: now } }, { endetAt: null }] },
-  });
-
-  return {
-    currentStatus: latest?.type ?? null,
-    since: latest?.startTime ?? null,
-    offeneKontrolle: offeneKontrolle
-      ? { deadline: offeneKontrolle.deadline, code: offeneKontrolle.code, kommentar: offeneKontrolle.kommentar, overdue: offeneKontrolle.deadline < now }
-      : null,
-    hasOffeneAnforderung: !!offeneVerschlussAnforderung,
-    hasActiveSperrzeit: !!activeSperrzeit,
-    offeneAnforderung: offeneVerschlussAnforderung
-      ? { id: offeneVerschlussAnforderung.id, nachricht: offeneVerschlussAnforderung.nachricht, endetAt: offeneVerschlussAnforderung.endetAt }
-      : null,
-    activeSperrzeit: activeSperrzeit
-      ? { id: activeSperrzeit.id, nachricht: activeSperrzeit.nachricht, endetAt: activeSperrzeit.endetAt }
-      : null,
-  };
-}
-
 export default async function AdminPage() {
   const session = await auth();
   const currentUserId = session?.user?.id;
@@ -66,11 +27,53 @@ export default async function AdminPage() {
   }
   const demoExists = users.some((u) => u.username === "DemoUser");
 
-  const usersWithStats = await Promise.all(
-    users.map(async (u) => ({ ...u, stats: await getUserStats(u.id) }))
-  );
-
+  const userIds = users.map(u => u.id);
   const now = new Date();
+
+  // Bulk-fetch all data in 4 queries instead of 4×N
+  const [allEntries, allKontrolle, allVerschlussAnf, allSperrzeiten] = await Promise.all([
+    prisma.entry.findMany({ where: { userId: { in: userIds } }, orderBy: { startTime: "asc" } }),
+    prisma.kontrollAnforderung.findMany({
+      where: { userId: { in: userIds }, entryId: null, withdrawnAt: null },
+      orderBy: { createdAt: "desc" },
+    }),
+    prisma.verschlussAnforderung.findMany({
+      where: { userId: { in: userIds }, art: "ANFORDERUNG", fulfilledAt: null, withdrawnAt: null },
+    }),
+    prisma.verschlussAnforderung.findMany({
+      where: { userId: { in: userIds }, art: "SPERRZEIT", withdrawnAt: null, OR: [{ endetAt: { gt: now } }, { endetAt: null }] },
+    }),
+  ]);
+
+  function getUserStats(userId: string) {
+    const entries = allEntries.filter(e => e.userId === userId);
+    const latest = [...entries]
+      .filter(e => e.type === "VERSCHLUSS" || e.type === "OEFFNEN")
+      .sort((a, b) => b.startTime.getTime() - a.startTime.getTime())[0] ?? null;
+
+    const offeneKontrolle = allKontrolle.find(k => k.userId === userId) ?? null;
+    const offeneVerschlussAnforderung = allVerschlussAnf.find(v => v.userId === userId) ?? null;
+    const activeSperrzeit = allSperrzeiten.find(s => s.userId === userId) ?? null;
+
+    return {
+      currentStatus: latest?.type ?? null,
+      since: latest?.startTime ?? null,
+      offeneKontrolle: offeneKontrolle
+        ? { deadline: offeneKontrolle.deadline, code: offeneKontrolle.code, kommentar: offeneKontrolle.kommentar, overdue: offeneKontrolle.deadline < now }
+        : null,
+      hasOffeneAnforderung: !!offeneVerschlussAnforderung,
+      hasActiveSperrzeit: !!activeSperrzeit,
+      offeneAnforderung: offeneVerschlussAnforderung
+        ? { id: offeneVerschlussAnforderung.id, nachricht: offeneVerschlussAnforderung.nachricht, endetAt: offeneVerschlussAnforderung.endetAt }
+        : null,
+      activeSperrzeit: activeSperrzeit
+        ? { id: activeSperrzeit.id, nachricht: activeSperrzeit.nachricht, endetAt: activeSperrzeit.endetAt }
+        : null,
+    };
+  }
+
+  const usersWithStats = users.map(u => ({ ...u, stats: getUserStats(u.id) }));
+
   const lockedCount = usersWithStats.filter(u => u.stats.currentStatus === "VERSCHLUSS").length;
   const alarmCount = usersWithStats.filter(u => u.stats.offeneKontrolle || u.stats.hasOffeneAnforderung).length;
 

--- a/src/app/admin/users/[id]/eintraege/page.tsx
+++ b/src/app/admin/users/[id]/eintraege/page.tsx
@@ -3,6 +3,7 @@ import { prisma } from "@/lib/prisma";
 import { redirect } from "next/navigation";
 import { Lock, LockOpen, ClipboardList, Droplets } from "lucide-react";
 import { getLocale } from "next-intl/server";
+import { formatDateTime } from "@/lib/utils";
 
 const TYPE_LABELS: Record<string, string> = {
   VERSCHLUSS: "Verschluss",
@@ -59,7 +60,7 @@ export default async function AdminUserEintraegePage({ params }: { params: Promi
                   {TYPE_LABELS[e.type] ?? e.type}
                 </span>
                 <span className="text-sm text-foreground tabular-nums">
-                  {e.startTime.toLocaleString(dl, { day: "2-digit", month: "2-digit", year: "numeric", hour: "2-digit", minute: "2-digit" })}
+                  {formatDateTime(e.startTime, dl)}
                 </span>
                 {e.orgasmusArt && (
                   <span className="text-xs text-[var(--color-orgasm)] font-medium">{e.orgasmusArt}</span>

--- a/src/app/api/entries/[id]/route.ts
+++ b/src/app/api/entries/[id]/route.ts
@@ -32,7 +32,8 @@ export async function PATCH(
       ...(oeffnenGrund !== undefined && { oeffnenGrund }),
       ...(orgasmusArt !== undefined && { orgasmusArt }),
       ...(kontrollCode !== undefined && { kontrollCode }),
-      ...(verifikationStatus !== undefined && { verifikationStatus }),
+      // verifikationStatus only settable by admins
+      ...(verifikationStatus !== undefined && session.user.role === "admin" && { verifikationStatus }),
     },
   });
 
@@ -54,11 +55,11 @@ export async function DELETE(
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
-  // Wenn eine Kontrolle gelöscht wird, KontrollAnforderung-Verknüpfung lösen
+  // Wenn eine Kontrolle gelöscht wird, KontrollAnforderung-Verknüpfung lösen (inkl. fulfilledAt)
   if (existing.type === "PRUEFUNG") {
     await prisma.kontrollAnforderung.updateMany({
       where: { entryId: id },
-      data: { entryId: null },
+      data: { entryId: null, fulfilledAt: null },
     });
   }
 

--- a/src/app/api/entries/route.ts
+++ b/src/app/api/entries/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { trackEvent } from "@/lib/telemetry";
+import { verifyKontrolleCode } from "@/lib/verifyCode";
 
 const VALID_TYPES = ["VERSCHLUSS", "OEFFNEN", "PRUEFUNG", "ORGASMUS"];
 const ORGASMUS_ARTEN = ["Orgasmus", "ruinierter Orgasmus", "feuchter Traum"];
@@ -24,7 +25,8 @@ export async function POST(req: NextRequest) {
   if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
   const body = await req.json();
-  const { type, startTime, imageUrl, imageExifTime, note, oeffnenGrund, orgasmusArt, kontrollCode, verifikationStatus } = body;
+  // verifikationStatus is never accepted from client – set server-side only
+  const { type, startTime, imageUrl, imageExifTime, note, oeffnenGrund, orgasmusArt, kontrollCode } = body;
 
   if (!startTime) return NextResponse.json({ error: "startTime is required" }, { status: 400 });
   if (new Date(startTime) > new Date()) {
@@ -33,34 +35,12 @@ export async function POST(req: NextRequest) {
   if (!type || !VALID_TYPES.includes(type)) {
     return NextResponse.json({ error: "Ungültiger Typ" }, { status: 400 });
   }
-  if (type === "VERSCHLUSS") {
-    const latest = await prisma.entry.findFirst({
-      where: { userId: session.user.id, type: { in: ["VERSCHLUSS", "OEFFNEN"] } },
-      orderBy: { startTime: "desc" },
-    });
-    if (latest?.type === "VERSCHLUSS") {
-      return NextResponse.json({ error: "Verschluss nur möglich wenn aktuell offen" }, { status: 400 });
-    }
-    if (latest?.type === "OEFFNEN" && new Date(startTime) <= latest.startTime) {
-      return NextResponse.json({ error: "Verschlusszeit muss nach der letzten Öffnungszeit liegen" }, { status: 400 });
-    }
-  }
   if (type === "OEFFNEN") {
     if (!oeffnenGrund || !OEFFNEN_GRUENDE.includes(oeffnenGrund)) {
       return NextResponse.json({ error: "Grund der Öffnung ist erforderlich" }, { status: 400 });
     }
     if (!note?.trim()) {
       return NextResponse.json({ error: "Kommentar ist erforderlich" }, { status: 400 });
-    }
-    const latest = await prisma.entry.findFirst({
-      where: { userId: session.user.id, type: { in: ["VERSCHLUSS", "OEFFNEN"] } },
-      orderBy: { startTime: "desc" },
-    });
-    if (!latest || latest.type !== "VERSCHLUSS") {
-      return NextResponse.json({ error: "Öffnen nur möglich wenn aktuell verschlossen" }, { status: 400 });
-    }
-    if (new Date(startTime) <= latest.startTime) {
-      return NextResponse.json({ error: "Öffnungszeit muss nach der letzten Verschlusszeit liegen" }, { status: 400 });
     }
   }
   if (type === "PRUEFUNG" && !imageUrl) {
@@ -71,52 +51,97 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Ungültige Art" }, { status: 400 });
   }
 
-  const entry = await prisma.entry.create({
-    data: {
-      userId: session.user.id,
-      type,
-      startTime: new Date(startTime),
-      imageUrl: imageUrl || null,
-      imageExifTime: imageExifTime ? new Date(imageExifTime) : null,
-      note: note || null,
-      oeffnenGrund: oeffnenGrund || null,
-      orgasmusArt: orgasmusArt || null,
-      kontrollCode: kontrollCode || null,
-      verifikationStatus: verifikationStatus || null,
-    },
-  });
+  // Wrap state-check + create in a transaction to prevent TOCTOU races
+  let entry: Awaited<ReturnType<typeof prisma.entry.create>>;
+  try {
+    entry = await prisma.$transaction(async (tx) => {
+      if (type === "VERSCHLUSS") {
+        const latest = await tx.entry.findFirst({
+          where: { userId: session.user.id, type: { in: ["VERSCHLUSS", "OEFFNEN"] } },
+          orderBy: { startTime: "desc" },
+        });
+        if (latest?.type === "VERSCHLUSS") throw Object.assign(new Error(), { _code: "ALREADY_LOCKED" });
+        if (latest?.type === "OEFFNEN" && new Date(startTime) <= latest.startTime) {
+          throw Object.assign(new Error(), { _code: "TIME_BEFORE" });
+        }
+      }
+      if (type === "OEFFNEN") {
+        const latest = await tx.entry.findFirst({
+          where: { userId: session.user.id, type: { in: ["VERSCHLUSS", "OEFFNEN"] } },
+          orderBy: { startTime: "desc" },
+        });
+        if (!latest || latest.type !== "VERSCHLUSS") throw Object.assign(new Error(), { _code: "NOT_LOCKED" });
+        if (new Date(startTime) <= latest.startTime) throw Object.assign(new Error(), { _code: "TIME_BEFORE" });
+      }
 
-  // KontrollAnforderung verknüpfen + fulfilledAt server-seitig setzen (unveränderlich)
-  if (type === "PRUEFUNG" && kontrollCode) {
-    await prisma.kontrollAnforderung.updateMany({
-      where: { userId: session.user.id, code: kontrollCode, entryId: null, withdrawnAt: null },
-      data: { entryId: entry.id, fulfilledAt: new Date() },
+      const created = await tx.entry.create({
+        data: {
+          userId: session.user.id,
+          type,
+          startTime: new Date(startTime),
+          imageUrl: imageUrl || null,
+          imageExifTime: imageExifTime ? new Date(imageExifTime) : null,
+          note: note || null,
+          oeffnenGrund: oeffnenGrund || null,
+          orgasmusArt: orgasmusArt || null,
+          kontrollCode: kontrollCode || null,
+          verifikationStatus: null,
+        },
+      });
+
+      // KontrollAnforderung verknüpfen + fulfilledAt server-seitig setzen (unveränderlich)
+      if (type === "PRUEFUNG" && kontrollCode) {
+        await tx.kontrollAnforderung.updateMany({
+          where: { userId: session.user.id, code: kontrollCode, entryId: null, withdrawnAt: null },
+          data: { entryId: created.id, fulfilledAt: new Date() },
+        });
+      }
+
+      // VerschlussAnforderung (ANFORDERUNG) als erfüllt markieren + ggf. SPERRZEIT erstellen
+      if (type === "VERSCHLUSS") {
+        const offeneAnforderung = await tx.verschlussAnforderung.findFirst({
+          where: { userId: session.user.id, art: "ANFORDERUNG", fulfilledAt: null, withdrawnAt: null },
+        });
+        if (offeneAnforderung) {
+          await tx.verschlussAnforderung.update({
+            where: { id: offeneAnforderung.id },
+            data: { fulfilledAt: new Date() },
+          });
+          if (offeneAnforderung.dauerH) {
+            await tx.verschlussAnforderung.create({
+              data: {
+                userId: session.user.id,
+                art: "SPERRZEIT",
+                nachricht: offeneAnforderung.nachricht,
+                endetAt: new Date(Date.now() + offeneAnforderung.dauerH * 60 * 60 * 1000),
+              },
+            });
+          }
+        }
+      }
+
+      return created;
     });
+  } catch (e: unknown) {
+    const code = (e as { _code?: string })?._code;
+    if (code === "ALREADY_LOCKED") return NextResponse.json({ error: "Verschluss nur möglich wenn aktuell offen" }, { status: 400 });
+    if (code === "NOT_LOCKED") return NextResponse.json({ error: "Öffnen nur möglich wenn aktuell verschlossen" }, { status: 400 });
+    if (code === "TIME_BEFORE") return NextResponse.json({ error: "Zeitpunkt muss nach dem vorherigen Eintrag liegen" }, { status: 400 });
+    throw e;
+  }
+
+  if (type === "PRUEFUNG" && kontrollCode) {
     trackEvent("kontrolle.fulfilled", { type });
   } else {
     trackEvent(`entry.created.${type}` as Parameters<typeof trackEvent>[0]);
   }
 
-  // VerschlussAnforderung (ANFORDERUNG) als erfüllt markieren + ggf. SPERRZEIT erstellen
-  if (type === "VERSCHLUSS") {
-    const offeneAnforderung = await prisma.verschlussAnforderung.findFirst({
-      where: { userId: session.user.id, art: "ANFORDERUNG", fulfilledAt: null, withdrawnAt: null },
-    });
-    if (offeneAnforderung) {
-      await prisma.verschlussAnforderung.update({
-        where: { id: offeneAnforderung.id },
-        data: { fulfilledAt: new Date() },
-      });
-      if (offeneAnforderung.dauerH) {
-        await prisma.verschlussAnforderung.create({
-          data: {
-            userId: session.user.id,
-            art: "SPERRZEIT",
-            nachricht: offeneAnforderung.nachricht,
-            endetAt: new Date(Date.now() + offeneAnforderung.dauerH * 60 * 60 * 1000),
-          },
-        });
-      }
+  // Server-side AI verification for PRUEFUNG entries — never trusted from client
+  if (type === "PRUEFUNG" && imageUrl && kontrollCode) {
+    const status = await verifyKontrolleCode(imageUrl, kontrollCode);
+    if (status) {
+      await prisma.entry.update({ where: { id: entry.id }, data: { verifikationStatus: status } });
+      entry = { ...entry, verifikationStatus: status };
     }
   }
 

--- a/src/app/components/StatsMain.tsx
+++ b/src/app/components/StatsMain.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 import { prisma } from "@/lib/prisma";
-import { formatDuration, formatDateTime, formatTime, formatHours, formatMs, toDateLocale, APP_TZ, mapAnforderungStatus, mapVerifikationStatus } from "@/lib/utils";
+import { formatDuration, formatDateTime, formatTime, formatHours, formatMs, toDateLocale, APP_TZ, mapAnforderungStatus, mapVerifikationStatus, getMidnightToday, getWeekStart, getMonthStart, tzDateParts, midnightInTZ } from "@/lib/utils";
 import { getKombinierterPill } from "@/lib/kontrollePills";
 import CalendarExpand from "./CalendarExpand";
 import { type CalendarMonthData, type CalendarDayData } from "./CalendarContainer";
@@ -73,19 +73,20 @@ function wearingHoursInRange(pairs: WearPair[], rangeStart: Date, rangeEnd: Date
 function buildDailyData(wearPairs: WearPair[], orgasmDates: Set<string>): Map<string, { hours: number; hasOrgasm: boolean }> {
   const map = new Map<string, { hours: number; hasOrgasm: boolean }>();
   for (const pair of wearPairs) {
-    let d = new Date(pair.start.getFullYear(), pair.start.getMonth(), pair.start.getDate());
-    const endDay = new Date(pair.end.getFullYear(), pair.end.getMonth(), pair.end.getDate());
-    while (d <= endDay) {
-      const dayBegin = new Date(d);
-      const dayEnd = new Date(d.getFullYear(), d.getMonth(), d.getDate() + 1);
-      const overlap = Math.min(pair.end.getTime(), dayEnd.getTime()) - Math.max(pair.start.getTime(), dayBegin.getTime());
+    // Start from midnight of pair.start in APP_TZ; advance by 24h steps
+    let d = midnightInTZ(pair.start);
+    while (d.getTime() < pair.end.getTime()) {
+      const nextD = new Date(d.getTime() + 86_400_000);
+      const overlap = Math.min(pair.end.getTime(), nextD.getTime()) - Math.max(pair.start.getTime(), d.getTime());
       if (overlap > 0) {
-        const key = `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`;
+        // Use midpoint of the 24h slice to reliably get the correct APP_TZ date
+        const { year, month, day } = tzDateParts(new Date(d.getTime() + 43_200_000));
+        const key = `${year}-${month}-${day}`;
         const existing = map.get(key) ?? { hours: 0, hasOrgasm: false };
-        existing.hours += overlap / 3600000;
+        existing.hours += overlap / 3_600_000;
         map.set(key, existing);
       }
-      d = new Date(d.getFullYear(), d.getMonth(), d.getDate() + 1);
+      d = nextD;
     }
   }
   for (const key of orgasmDates) {
@@ -97,12 +98,19 @@ function buildDailyData(wearPairs: WearPair[], orgasmDates: Set<string>): Map<st
 }
 
 
+function tzYearMonth(d: Date): string {
+  const parts = new Intl.DateTimeFormat("de-CH", { year: "numeric", month: "2-digit", timeZone: APP_TZ }).formatToParts(d);
+  const y = parts.find(p => p.type === "year")!.value;
+  const m = parts.find(p => p.type === "month")!.value;
+  return `${y}-${m}`;
+}
+
 function buildMonthStats(pairs: CompletedPair[], wearPairs: WearPair[], vorgaben: Vorgabe[], dl = "de-CH"): MonthStat[] {
   const map = new Map<string, Omit<MonthStat, "wearHours" | "targetH">>();
   for (const p of pairs) {
     const d = p.verschluss.startTime;
-    const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
-    const label = d.toLocaleString(dl, { month: "long", year: "numeric" });
+    const key = tzYearMonth(d);
+    const label = d.toLocaleString(dl, { month: "long", year: "numeric", timeZone: APP_TZ });
     const existing = map.get(key) ?? { key, label, count: 0, totalMs: 0, longestMs: 0 };
     existing.count++;
     existing.totalMs += p.durationMs;
@@ -111,9 +119,9 @@ function buildMonthStats(pairs: CompletedPair[], wearPairs: WearPair[], vorgaben
   }
   for (const wp of wearPairs) {
     for (const d of [wp.start, wp.end]) {
-      const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+      const key = tzYearMonth(d);
       if (!map.has(key)) {
-        const label = d.toLocaleString(dl, { month: "long", year: "numeric" });
+        const label = d.toLocaleString(dl, { month: "long", year: "numeric", timeZone: APP_TZ });
         map.set(key, { key, label, count: 0, totalMs: 0, longestMs: 0 });
       }
     }
@@ -122,8 +130,8 @@ function buildMonthStats(pairs: CompletedPair[], wearPairs: WearPair[], vorgaben
     .sort((a, b) => b[0].localeCompare(a[0]))
     .map(([, v]) => {
       const [y, m] = v.key.split("-").map(Number);
-      const monthStart = new Date(y, m - 1, 1);
-      const monthEnd = new Date(y, m, 1);
+      const monthStart = midnightInTZ(new Date(Date.UTC(y, m - 1, 1, 12)));
+      const monthEnd = midnightInTZ(new Date(Date.UTC(y, m, 1, 12)));
       const wearHours = wearingHoursInRange(wearPairs, monthStart, monthEnd);
       const applicableVorgabe = vorgaben.find(
         (vg) => vg.gueltigAb < monthEnd && (vg.gueltigBis === null || vg.gueltigBis >= monthStart)
@@ -219,10 +227,9 @@ export default async function StatsMain({ userId, heading, backHref, backLabel }
   const wearPairs = buildWearPairs(entries, now);
   const monthStats = buildMonthStats(completed, wearPairs, vorgaben, dl);
 
-  const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-  const weekStart = new Date(todayStart);
-  weekStart.setDate(todayStart.getDate() - ((todayStart.getDay() + 6) % 7));
-  const monthStart = new Date(now.getFullYear(), now.getMonth(), 1);
+  const todayStart = getMidnightToday(now);
+  const weekStart = getWeekStart(now);
+  const monthStart = getMonthStart(now);
 
   const hoursToday = wearingHoursInRange(wearPairs, todayStart, now);
   const hoursWeek = wearingHoursInRange(wearPairs, weekStart, now);
@@ -230,23 +237,27 @@ export default async function StatsMain({ userId, heading, backHref, backLabel }
 
   const orgasmDateSet = new Set<string>(
     entries.filter((e) => e.type === "ORGASMUS")
-      .map((e) => `${e.startTime.getFullYear()}-${e.startTime.getMonth()}-${e.startTime.getDate()}`)
+      .map((e) => { const { year, month, day } = tzDateParts(e.startTime); return `${year}-${month}-${day}`; })
   );
   const dailyData = buildDailyData(wearPairs, orgasmDateSet);
 
   // Build serializable calendar data for CalendarContainer
+  const { year: nowYear, month: nowMonth } = tzDateParts(now);
+  const jsWeekdayMap: Record<string, number> = { Sun: 0, Mon: 1, Tue: 2, Wed: 3, Thu: 4, Fri: 5, Sat: 6 };
+
   const calMonthsData: CalendarMonthData[] = [];
   for (let i = 0; i <= 3; i++) {
-    const d = new Date(now.getFullYear(), now.getMonth() - i, 1);
-    const year = d.getFullYear();
-    const month = d.getMonth();
-    const firstDay = new Date(year, month, 1);
-    const daysInMonth = new Date(year, month + 1, 0).getDate();
-    const startOffset = (firstDay.getDay() + 6) % 7;
-    const label = firstDay.toLocaleString(dl, { month: "long", year: "numeric" });
+    // Compute calendar year/month in APP_TZ by stepping back i months
+    const { year, month } = tzDateParts(new Date(Date.UTC(nowYear, nowMonth - i, 1, 12)));
+    const daysInMonth = new Date(Date.UTC(year, month + 1, 0)).getUTCDate();
+    const firstDayNoon = new Date(Date.UTC(year, month, 1, 12));
+    const firstDayWd = new Intl.DateTimeFormat("en-US", { timeZone: APP_TZ, weekday: "short" })
+      .formatToParts(firstDayNoon).find(p => p.type === "weekday")!.value;
+    const startOffset = (jsWeekdayMap[firstDayWd] + 6) % 7;
+    const label = firstDayNoon.toLocaleString(dl, { month: "long", year: "numeric", timeZone: APP_TZ });
 
-    const monthStart = new Date(year, month, 1);
-    const monthEnd = new Date(year, month + 1, 1);
+    const monthStart = midnightInTZ(firstDayNoon);
+    const monthEnd = midnightInTZ(new Date(Date.UTC(year, month + 1, 1, 12)));
     const vorgabe = vorgaben.find(
       (vg) => vg.gueltigAb < monthEnd && (vg.gueltigBis === null || vg.gueltigBis >= monthStart)
     ) ?? null;
@@ -269,10 +280,12 @@ export default async function StatsMain({ userId, heading, backHref, backLabel }
       const firstDayOfRow = weekCells.find((x) => x != null);
       let weekH = 0;
       if (firstDayOfRow != null && vorgabe?.minProWocheH != null) {
-        const anchor = new Date(year, month, firstDayOfRow);
-        const dow = (anchor.getDay() + 6) % 7;
-        const wkStart = new Date(anchor.getFullYear(), anchor.getMonth(), anchor.getDate() - dow);
-        const wkEnd = new Date(wkStart.getFullYear(), wkStart.getMonth(), wkStart.getDate() + 7);
+        const anchorNoon = new Date(Date.UTC(year, month, firstDayOfRow, 12));
+        const anchorWd = new Intl.DateTimeFormat("en-US", { timeZone: APP_TZ, weekday: "short" })
+          .formatToParts(anchorNoon).find(p => p.type === "weekday")!.value;
+        const dow = (jsWeekdayMap[anchorWd] + 6) % 7;
+        const wkStart = midnightInTZ(new Date(Date.UTC(year, month, firstDayOfRow - dow, 12)));
+        const wkEnd = new Date(wkStart.getTime() + 7 * 86_400_000);
         weekH = wearingHoursInRange(wearPairs, wkStart, wkEnd);
       }
       weekGoalMet.push(vorgabe?.minProWocheH != null && firstDayOfRow != null ? weekH >= vorgabe.minProWocheH : null);
@@ -290,7 +303,7 @@ export default async function StatsMain({ userId, heading, backHref, backLabel }
           : pct < 0.65 ? "bg-blue-400 text-white"
           : "bg-blue-600 text-white";
         const dayEntries: DayEntry[] = entries
-          .filter((e) => e.startTime.getFullYear() === year && e.startTime.getMonth() === month && e.startTime.getDate() === day)
+          .filter((e) => { const p = tzDateParts(e.startTime); return p.year === year && p.month === month && p.day === day; })
           .sort((a, b) => a.startTime.getTime() - b.startTime.getTime())
           .map((e) => ({
             type: e.type,
@@ -302,7 +315,7 @@ export default async function StatsMain({ userId, heading, backHref, backLabel }
           minProTagH: vorgabe.minProTagH, minProWocheH: vorgabe.minProWocheH,
           minProMonatH: vorgabe.minProMonatH, notiz: vorgabe.notiz,
         } : null;
-        const dateLabel = new Date(year, month, day).toLocaleDateString(dl, { day: "numeric", month: "long", year: "numeric", timeZone: APP_TZ });
+        const dateLabel = new Date(Date.UTC(year, month, day, 12)).toLocaleDateString(dl, { day: "numeric", month: "long", year: "numeric", timeZone: APP_TZ });
         return { day, dateLabel, wearHours: data?.hours ?? 0, hasOrgasm: data?.hasOrgasm ?? false, dailyGoalMet, colorClass, entries: dayEntries, vorgabe: dayVorgabe };
       }));
     }

--- a/src/app/dashboard/OeffnenForm.tsx
+++ b/src/app/dashboard/OeffnenForm.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { toDatetimeLocal, toDateLocale } from "@/lib/utils";
+import { toDatetimeLocal, toDateLocale, APP_TZ } from "@/lib/utils";
 import { AlertCircle, Lock } from "lucide-react";
 import { useTranslations, useLocale } from "next-intl";
 
@@ -91,7 +91,7 @@ export default function OeffnenForm({ initial, sperrzeitEndetAt, sperrzeitUnbefr
                   {sperrzeitUnbefristet
                     ? t("modalLockedIndefinite")
                     : sperrzeitEndetAt
-                      ? t("modalLockedUntil", { date: new Date(sperrzeitEndetAt).toLocaleString(dl, { day: "2-digit", month: "2-digit", year: "numeric", hour: "2-digit", minute: "2-digit" }) })
+                      ? t("modalLockedUntil", { date: new Date(sperrzeitEndetAt).toLocaleString(dl, { day: "2-digit", month: "2-digit", year: "numeric", hour: "2-digit", minute: "2-digit", timeZone: APP_TZ }) })
                       : null}
                 </p>
               </div>
@@ -127,7 +127,7 @@ export default function OeffnenForm({ initial, sperrzeitEndetAt, sperrzeitUnbefr
               <p className="text-xs text-[var(--color-sperrzeit)] mt-0.5">
                 {sperrzeitUnbefristet
                   ? t("lockedWarningTextIndefinite")
-                  : t("lockedWarningText", { date: new Date(sperrzeitEndetAt!).toLocaleString(dl, { day: "2-digit", month: "2-digit", year: "numeric", hour: "2-digit", minute: "2-digit" }) })}
+                  : t("lockedWarningText", { date: new Date(sperrzeitEndetAt!).toLocaleString(dl, { day: "2-digit", month: "2-digit", year: "numeric", hour: "2-digit", minute: "2-digit", timeZone: APP_TZ }) })}
               </p>
             </div>
           </div>

--- a/src/app/dashboard/PairRow.tsx
+++ b/src/app/dashboard/PairRow.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useRef } from "react";
 import { X, Lock, LockOpen, Timer, ImageOff } from "lucide-react";
-import { formatDateTime, toDateLocale } from "@/lib/utils";
+import { formatDateTime, toDateLocale, APP_TZ } from "@/lib/utils";
 import { useTranslations, useLocale } from "next-intl";
 
 const GRUND_LABELS: Record<string, string> = {
@@ -207,8 +207,8 @@ export default function PairRow({ verschluss, oeffnen, active, duration, photoSt
   function splitDT(iso: string) {
     const d = new Date(iso);
     return {
-      date: d.toLocaleDateString(dl, { day: "2-digit", month: "2-digit", year: "numeric" }),
-      time: d.toLocaleTimeString(dl, { hour: "2-digit", minute: "2-digit" }),
+      date: d.toLocaleDateString(dl, { day: "2-digit", month: "2-digit", year: "numeric", timeZone: APP_TZ }),
+      time: d.toLocaleTimeString(dl, { hour: "2-digit", minute: "2-digit", timeZone: APP_TZ }),
     };
   }
 

--- a/src/app/dashboard/StatusBanner.tsx
+++ b/src/app/dashboard/StatusBanner.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import { HelpCircle, Lock, LockOpen } from "lucide-react";
 import { useTranslations, useLocale } from "next-intl";
-import { toDateLocale, formatElapsedMs } from "@/lib/utils";
+import { toDateLocale, formatElapsedMs, APP_TZ } from "@/lib/utils";
 
 interface Props {
   type: "VERSCHLUSS" | "OEFFNEN" | null;
@@ -65,7 +65,7 @@ export default function StatusBanner({ type, since }: Props) {
           </div>
         </div>
         <p className="text-xs opacity-60 mt-1">
-          {t("since")} {sinceDate.toLocaleString(dl, { day: "2-digit", month: "2-digit", year: "numeric", hour: "2-digit", minute: "2-digit" })}
+          {t("since")} {sinceDate.toLocaleString(dl, { day: "2-digit", month: "2-digit", year: "numeric", hour: "2-digit", minute: "2-digit", timeZone: APP_TZ })}
         </p>
       </div>
     </div>

--- a/src/app/dashboard/edit/[id]/page.tsx
+++ b/src/app/dashboard/edit/[id]/page.tsx
@@ -25,7 +25,7 @@ export default async function EditEntryPage({
     userId ? prisma.user.findUnique({ where: { id: userId }, select: { mobileDesktopUpload: true } }) : null,
   ]);
   const mobileDesktopMode = dbUser?.mobileDesktopUpload ?? false;
-  if (!entry) notFound();
+  if (!entry || entry.userId !== userId) notFound();
 
   const LABELS: Record<string, string> = {
     VERSCHLUSS: tStats("lock"),

--- a/src/app/dashboard/eintraege/page.tsx
+++ b/src/app/dashboard/eintraege/page.tsx
@@ -4,6 +4,7 @@ import { redirect } from "next/navigation";
 import { Lock, LockOpen, ClipboardList, Droplets, MoreVertical } from "lucide-react";
 import Link from "next/link";
 import { getLocale } from "next-intl/server";
+import { formatDateTime } from "@/lib/utils";
 
 const TYPE_LABELS: Record<string, string> = {
   VERSCHLUSS: "Verschluss",
@@ -57,7 +58,7 @@ export default async function EintraegePage() {
                   {TYPE_LABELS[e.type] ?? e.type}
                 </span>
                 <span className="text-sm text-foreground tabular-nums">
-                  {e.startTime.toLocaleString(dl, { day: "2-digit", month: "2-digit", year: "numeric", hour: "2-digit", minute: "2-digit" })}
+                  {formatDateTime(e.startTime, dl)}
                 </span>
                 {e.orgasmusArt && (
                   <span className="text-xs text-[var(--color-orgasm)] font-medium">{e.orgasmusArt}</span>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -70,24 +70,50 @@ export function formatTime(date: Date | string, locale = "de-CH"): string {
   });
 }
 
-/** Today at 00:00:00 local time */
+/** Returns { year, 0-based month, day } of `d` in APP_TZ. */
+export function tzDateParts(d: Date): { year: number; month: number; day: number } {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: APP_TZ,
+    year: "numeric", month: "numeric", day: "numeric",
+  }).formatToParts(d);
+  const get = (type: string) => +(parts.find(p => p.type === type)?.value ?? "0");
+  return { year: get("year"), month: get("month") - 1, day: get("day") };
+}
+
+/** Returns the Date representing 00:00:00 in APP_TZ on the same calendar date as `d`. */
+export function midnightInTZ(d: Date): Date {
+  const { year, month, day } = tzDateParts(d);
+  // Compute TZ offset at noon of that calendar day (safe from DST edge cases)
+  const noonUTC = Date.UTC(year, month, day, 12);
+  const p = new Intl.DateTimeFormat("en-US", {
+    timeZone: APP_TZ,
+    year: "numeric", month: "numeric", day: "numeric",
+    hour: "numeric", minute: "numeric", second: "numeric",
+    hour12: false,
+  }).formatToParts(new Date(noonUTC));
+  const g = (type: string) => +(p.find(x => x.type === type)?.value ?? "0");
+  const h = g("hour");
+  const tzNoonMs = Date.UTC(g("year"), g("month") - 1, g("day"), h === 24 ? 0 : h, g("minute"), g("second"));
+  return new Date(Date.UTC(year, month, day) + (noonUTC - tzNoonMs));
+}
+
+/** Today at 00:00:00 in APP_TZ */
 export function getMidnightToday(now: Date): Date {
-  const d = new Date(now);
-  d.setHours(0, 0, 0, 0);
-  return d;
+  return midnightInTZ(now);
 }
 
-/** Start of the current ISO week (Monday 00:00:00 local time) */
+/** Start of the current ISO week (Monday 00:00:00 in APP_TZ) */
 export function getWeekStart(now: Date): Date {
-  const d = new Date(now);
-  d.setDate(d.getDate() - ((d.getDay() + 6) % 7));
-  d.setHours(0, 0, 0, 0);
-  return d;
+  const p = new Intl.DateTimeFormat("en-US", { timeZone: APP_TZ, weekday: "short" }).formatToParts(now);
+  const map: Record<string, number> = { Sun: 0, Mon: 1, Tue: 2, Wed: 3, Thu: 4, Fri: 5, Sat: 6 };
+  const dow = ((map[p.find(x => x.type === "weekday")!.value] ?? 0) + 6) % 7;
+  return new Date(midnightInTZ(now).getTime() - dow * 86_400_000);
 }
 
-/** First day of the current month at 00:00:00 local time */
+/** First day of the current month at 00:00:00 in APP_TZ */
 export function getMonthStart(now: Date): Date {
-  return new Date(now.getFullYear(), now.getMonth(), 1);
+  const { year, month } = tzDateParts(now);
+  return midnightInTZ(new Date(Date.UTC(year, month, 1, 12)));
 }
 
 /** Live-elapsed format: always includes minutes ("2T 3h 14min"). Takes pre-computed ms. */

--- a/src/lib/verifyCode.ts
+++ b/src/lib/verifyCode.ts
@@ -1,0 +1,72 @@
+import { readFile } from "fs/promises";
+import { join, basename } from "path";
+import Anthropic from "@anthropic-ai/sdk";
+
+const MEDIA_TYPES: Record<string, "image/jpeg" | "image/png" | "image/gif" | "image/webp"> = {
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  png: "image/png",
+  gif: "image/gif",
+  webp: "image/webp",
+};
+
+function fuzzyMatch(a: string, b: string): boolean {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  const similar: Record<string, string> = { "1": "7", "7": "1", "0": "6", "6": "0" };
+  return a.split("").every((ch, i) => ch === b[i] || similar[ch] === b[i]);
+}
+
+/**
+ * Runs the Claude Vision check for a handwritten Kontrolle code.
+ * Returns "ai" if the code matches, null otherwise (or on any error).
+ * Reads the image from the local uploads directory.
+ */
+export async function verifyKontrolleCode(
+  imageUrl: string,
+  expectedCode: string
+): Promise<"ai" | null> {
+  try {
+    const filename = basename(imageUrl);
+    if (!filename || filename.includes("..") || filename.includes("/")) return null;
+
+    const buffer = await readFile(join(process.cwd(), "data", "uploads", filename));
+    const base64 = buffer.toString("base64");
+    const ext = filename.split(".").pop()?.toLowerCase() ?? "";
+    const mediaType = MEDIA_TYPES[ext] ?? "image/jpeg";
+
+    const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+    const response = await client.messages.create({
+      model: "claude-haiku-4-5-20251001",
+      max_tokens: 100,
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "image", source: { type: "base64", media_type: mediaType, data: base64 } },
+            {
+              type: "text",
+              text: `This image should contain a handwritten 5-digit number: ${expectedCode}.\nLook carefully for any handwritten digits in the image. Note: handwritten "1" often looks like "7" and vice versa – read carefully.\nReply with JSON only: {"detected": "<5-digit code or null>", "match": true/false, "reason": "<brief reason in German if match is false, else null>"}.\nPossible reasons (pick the most fitting, keep it short): "Kein Code sichtbar", "Bild zu unscharf", "Code verdeckt oder abgeschnitten", "Schrift nicht lesbar", "Falscher Code sichtbar: <detected>", "Bild zu dunkel", "Kein handgeschriebener Code gefunden".`,
+            },
+          ],
+        },
+      ],
+    });
+
+    const text = response.content[0].type === "text" ? response.content[0].text : "";
+    const policyKeywords = ["I'm unable", "I cannot", "I can't", "inappropriate", "violates", "policy", "explicit", "sorry, I"];
+    if (!text.includes("{") && policyKeywords.some(kw => text.toLowerCase().includes(kw.toLowerCase()))) {
+      return null;
+    }
+
+    const jsonMatch = text.match(/\{[\s\S]*\}/);
+    if (!jsonMatch) return null;
+
+    const result = JSON.parse(jsonMatch[0]);
+    const detected: string | null = result.detected ?? null;
+    const isMatch = result.match === true || (detected !== null && fuzzyMatch(detected, expectedCode));
+    return isMatch ? "ai" : null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

- **Security:** `verifikationStatus` wird nicht mehr vom Client akzeptiert — AI-Check (Claude Vision) läuft jetzt serverseitig in `lib/verifyCode.ts`
- **Security:** Edit-Page prüft Ownership (`entry.userId !== userId → notFound`)
- **Security:** PATCH `verifikationStatus` nur noch für Admins
- **Bug:** `fulfilledAt` wird beim DELETE einer Kontrolle zurückgesetzt (verhindert falsches "late"-Status nach Neueinreichung)
- **Bug:** TOCTOU-Race bei VERSCHLUSS/ÖFFNEN durch `prisma.$transaction` eliminiert
- **Timezone:** `tzDateParts()` + `midnightInTZ()` in `utils.ts`; alle Tages-/Wochen-/Monatsgrenzen auf `APP_TZ = "Europe/Zurich"` umgestellt (StatsMain Kalender, `buildDailyData`, `orgasmDateSet`, Wochen-/Monatsgrenzen, Einträge-Tabellen, `StatusBanner`, `PairRow`, `OeffnenForm`)
- **Performance:** Admin-Panel N+1 → 4 Bulk-Queries

## Test plan

- [ ] PRUEFUNG einreichen: `verifikationStatus` muss `"ai"` sein wenn Code korrekt (serverseitig gesetzt)
- [ ] Als normaler User PATCH mit `verifikationStatus: "manual"` → darf nicht übernommen werden
- [ ] `/dashboard/edit/<fremde-id>` → muss 404 zurückgeben
- [ ] Kontrolle löschen und neu einreichen → Status darf nicht mehr "late" zeigen
- [ ] Zwei simultane VERSCHLUSS-Requests → nur einer darf durchkommen
- [ ] Stats/Kalender: Tagesgrenzen um Mitternacht Zürich korrekt (nicht UTC)
- [ ] Admin-Panel lädt schnell auch bei vielen Usern

🤖 Generated with [Claude Code](https://claude.com/claude-code)