### PR TITLE
fix: second code review – security, timezone und logic fixes (v2.0.8)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kg-app",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/api/admin/entries/route.ts
+++ b/src/app/api/admin/entries/route.ts
@@ -27,29 +27,12 @@ export async function POST(req: NextRequest) {
   const user = await prisma.user.findUnique({ where: { id: userId } });
   if (!user) return NextResponse.json({ error: "Benutzer nicht gefunden" }, { status: 404 });
 
-  if (type === "VERSCHLUSS") {
-    const latest = await prisma.entry.findFirst({
-      where: { userId, type: { in: ["VERSCHLUSS", "OEFFNEN"] } },
-      orderBy: { startTime: "desc" },
-    });
-    if (latest?.type === "VERSCHLUSS") {
-      return NextResponse.json({ error: "Verschluss nur möglich wenn aktuell offen" }, { status: 400 });
-    }
-  }
-
   if (type === "OEFFNEN") {
     if (!oeffnenGrund || !OEFFNEN_GRUENDE.includes(oeffnenGrund)) {
       return NextResponse.json({ error: "Grund der Öffnung ist erforderlich" }, { status: 400 });
     }
     if (!note?.trim()) {
       return NextResponse.json({ error: "Kommentar ist erforderlich" }, { status: 400 });
-    }
-    const latest = await prisma.entry.findFirst({
-      where: { userId, type: { in: ["VERSCHLUSS", "OEFFNEN"] } },
-      orderBy: { startTime: "desc" },
-    });
-    if (!latest || latest.type !== "VERSCHLUSS") {
-      return NextResponse.json({ error: "Öffnen nur möglich wenn aktuell verschlossen" }, { status: 400 });
     }
   }
 
@@ -58,18 +41,44 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Ungültige Art" }, { status: 400 });
   }
 
-  const entry = await prisma.entry.create({
-    data: {
-      userId,
-      type,
-      startTime: new Date(startTime),
-      note: note?.trim() || null,
-      oeffnenGrund: oeffnenGrund || null,
-      orgasmusArt: orgasmusArt || null,
-      imageUrl: imageUrl || null,
-      imageExifTime: imageExifTime ? new Date(imageExifTime) : null,
-    },
-  });
+  let entry;
+  try {
+    entry = await prisma.$transaction(async (tx) => {
+      if (type === "VERSCHLUSS") {
+        const latest = await tx.entry.findFirst({
+          where: { userId, type: { in: ["VERSCHLUSS", "OEFFNEN"] } },
+          orderBy: { startTime: "desc" },
+        });
+        if (latest?.type === "VERSCHLUSS") throw Object.assign(new Error(), { _code: "ALREADY_LOCKED" });
+      }
+
+      if (type === "OEFFNEN") {
+        const latest = await tx.entry.findFirst({
+          where: { userId, type: { in: ["VERSCHLUSS", "OEFFNEN"] } },
+          orderBy: { startTime: "desc" },
+        });
+        if (!latest || latest.type !== "VERSCHLUSS") throw Object.assign(new Error(), { _code: "NOT_LOCKED" });
+      }
+
+      return tx.entry.create({
+        data: {
+          userId,
+          type,
+          startTime: new Date(startTime),
+          note: note?.trim() || null,
+          oeffnenGrund: oeffnenGrund || null,
+          orgasmusArt: orgasmusArt || null,
+          imageUrl: imageUrl || null,
+          imageExifTime: imageExifTime ? new Date(imageExifTime) : null,
+        },
+      });
+    });
+  } catch (e: unknown) {
+    const code = (e as { _code?: string })?._code;
+    if (code === "ALREADY_LOCKED") return NextResponse.json({ error: "Verschluss nur möglich wenn aktuell offen" }, { status: 400 });
+    if (code === "NOT_LOCKED") return NextResponse.json({ error: "Öffnen nur möglich wenn aktuell verschlossen" }, { status: 400 });
+    throw e;
+  }
 
   return NextResponse.json(entry, { status: 201 });
 }

--- a/src/app/api/admin/vorgaben/[id]/route.ts
+++ b/src/app/api/admin/vorgaben/[id]/route.ts
@@ -12,6 +12,9 @@ export async function PATCH(
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
   const { id } = await params;
+  const existing = await prisma.trainingVorgabe.findUnique({ where: { id } });
+  if (!existing) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
   const { gueltigAb, gueltigBis, minProTagH, minProWocheH, minProMonatH, notiz } = await req.json();
   const vorgabe = await prisma.trainingVorgabe.update({
     where: { id },
@@ -38,6 +41,9 @@ export async function DELETE(
   }
 
   const { id } = await params;
+  const toDelete = await prisma.trainingVorgabe.findUnique({ where: { id }, select: { userId: true } });
+  if (!toDelete) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
   const deleted = await prisma.trainingVorgabe.delete({ where: { id }, select: { userId: true } });
   await reorderVorgabenDates(deleted.userId);
   return new NextResponse(null, { status: 204 });

--- a/src/app/api/entries/[id]/route.ts
+++ b/src/app/api/entries/[id]/route.ts
@@ -20,22 +20,49 @@ export async function PATCH(
   const body = await req.json();
   const { startTime, imageUrl, imageExifTime, note, oeffnenGrund, orgasmusArt, kontrollCode, verifikationStatus } = body;
 
-  const entry = await prisma.entry.update({
-    where: { id },
-    data: {
-      ...(startTime && { startTime: new Date(startTime) }),
-      ...(imageUrl !== undefined && { imageUrl }),
-      ...(imageExifTime !== undefined && {
-        imageExifTime: imageExifTime ? new Date(imageExifTime) : null,
-      }),
-      ...(note !== undefined && { note }),
-      ...(oeffnenGrund !== undefined && { oeffnenGrund }),
-      ...(orgasmusArt !== undefined && { orgasmusArt }),
-      ...(kontrollCode !== undefined && { kontrollCode }),
-      // verifikationStatus only settable by admins
-      ...(verifikationStatus !== undefined && session.user.role === "admin" && { verifikationStatus }),
-    },
-  });
+  let entry;
+  try {
+    entry = await prisma.$transaction(async (tx) => {
+      // Re-validate temporal ordering when startTime is changed on a VERSCHLUSS/OEFFNEN entry
+      if (startTime && (existing.type === "VERSCHLUSS" || existing.type === "OEFFNEN")) {
+        const newTime = new Date(startTime);
+        if (newTime > new Date()) throw Object.assign(new Error(), { _code: "FUTURE" });
+        const allVO = await tx.entry.findMany({
+          where: { userId: existing.userId, type: { in: ["VERSCHLUSS", "OEFFNEN"] }, id: { not: id } },
+          orderBy: { startTime: "asc" },
+          select: { type: true, startTime: true },
+        });
+        const insertIdx = allVO.findIndex(e => e.startTime > newTime);
+        const prev = insertIdx === -1 ? allVO[allVO.length - 1] : allVO[insertIdx - 1];
+        const next = insertIdx === -1 ? null : allVO[insertIdx];
+        if ((prev && prev.type === existing.type) || (next && next.type === existing.type)) {
+          throw Object.assign(new Error(), { _code: "INVALID_ORDER" });
+        }
+      }
+
+      return tx.entry.update({
+        where: { id },
+        data: {
+          ...(startTime && { startTime: new Date(startTime) }),
+          ...(imageUrl !== undefined && { imageUrl }),
+          ...(imageExifTime !== undefined && {
+            imageExifTime: imageExifTime ? new Date(imageExifTime) : null,
+          }),
+          ...(note !== undefined && { note }),
+          ...(oeffnenGrund !== undefined && { oeffnenGrund }),
+          ...(orgasmusArt !== undefined && { orgasmusArt }),
+          ...(kontrollCode !== undefined && { kontrollCode }),
+          // verifikationStatus only settable by admins
+          ...(verifikationStatus !== undefined && session.user.role === "admin" && { verifikationStatus }),
+        },
+      });
+    });
+  } catch (e: unknown) {
+    const code = (e as { _code?: string })?._code;
+    if (code === "FUTURE") return NextResponse.json({ error: "Zeitpunkt darf nicht in der Zukunft liegen" }, { status: 400 });
+    if (code === "INVALID_ORDER") return NextResponse.json({ error: "Zeitpunkt verletzt die chronologische Reihenfolge" }, { status: 400 });
+    throw e;
+  }
 
   return NextResponse.json(entry);
 }
@@ -55,15 +82,16 @@ export async function DELETE(
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
-  // Wenn eine Kontrolle gelöscht wird, KontrollAnforderung-Verknüpfung lösen (inkl. fulfilledAt)
-  if (existing.type === "PRUEFUNG") {
-    await prisma.kontrollAnforderung.updateMany({
-      where: { entryId: id },
-      data: { entryId: null, fulfilledAt: null },
-    });
-  }
-
-  await prisma.entry.delete({ where: { id } });
+  // Atomares Unlink + Delete in einer Transaktion
+  await prisma.$transaction(async (tx) => {
+    if (existing.type === "PRUEFUNG") {
+      await tx.kontrollAnforderung.updateMany({
+        where: { entryId: id },
+        data: { entryId: null, fulfilledAt: null },
+      });
+    }
+    await tx.entry.delete({ where: { id } });
+  });
 
   return new NextResponse(null, { status: 204 });
 }

--- a/src/app/api/uploads/[...path]/route.ts
+++ b/src/app/api/uploads/[...path]/route.ts
@@ -1,7 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
 import { readFile } from "fs/promises";
-import { join, extname } from "path";
+import { join, extname, resolve, sep } from "path";
 
 const MIME: Record<string, string> = {
   ".jpg": "image/jpeg",
@@ -22,13 +23,22 @@ export async function GET(
   const { path } = await params;
   const filename = path.join("/");
 
-  // Prevent path traversal
-  if (filename.includes("..")) {
+  // Prevent path traversal via resolve + prefix check
+  const uploadsDir = resolve(join(process.cwd(), "data", "uploads"));
+  const filepath = resolve(join(uploadsDir, filename));
+  if (!filepath.startsWith(uploadsDir + sep)) {
     return new NextResponse("Forbidden", { status: 403 });
   }
 
-  const uploadsDir = join(process.cwd(), "data", "uploads");
-  const filepath = join(uploadsDir, filename);
+  // Ownership: only the entry owner or an admin may access the file
+  const imageUrlInDb = `/api/uploads/${filename}`;
+  const ownedEntry = await prisma.entry.findFirst({
+    where: { imageUrl: imageUrlInDb, userId: session.user.id },
+    select: { id: true },
+  });
+  if (!ownedEntry && session.user.role !== "admin") {
+    return new NextResponse("Forbidden", { status: 403 });
+  }
 
   try {
     const buffer = await readFile(filepath);

--- a/src/app/api/verify-kontrolle/route.ts
+++ b/src/app/api/verify-kontrolle/route.ts
@@ -1,12 +1,31 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
-import { readFile } from "fs/promises";
-import { join, basename } from "path";
-import Anthropic from "@anthropic-ai/sdk";
+import { verifyKontrolleCodeDetailed } from "@/lib/verifyCode";
+
+// Per-user rate limiting: max 10 requests per 60 s
+const rateLimitMap = new Map<string, { count: number; resetAt: number }>();
+const RATE_WINDOW_MS = 60_000;
+const RATE_MAX = 10;
+
+function checkRateLimit(userId: string): boolean {
+  const now = Date.now();
+  const entry = rateLimitMap.get(userId);
+  if (!entry || entry.resetAt < now) {
+    rateLimitMap.set(userId, { count: 1, resetAt: now + RATE_WINDOW_MS });
+    return true;
+  }
+  if (entry.count >= RATE_MAX) return false;
+  entry.count++;
+  return true;
+}
 
 export async function POST(req: NextRequest) {
   const session = await auth();
   if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  if (!checkRateLimit(session.user.id)) {
+    return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+  }
 
   const { imageUrl, expectedCode } = await req.json();
 
@@ -14,84 +33,10 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "imageUrl and expectedCode required" }, { status: 400 });
   }
 
-  // Extract filename from URL like /api/uploads/<filename>
-  const filename = basename(imageUrl);
-  if (filename.includes("..")) {
-    return NextResponse.json({ error: "Invalid imageUrl" }, { status: 400 });
-  }
-
-  try {
-    const uploadsDir = join(process.cwd(), "data", "uploads");
-    const buffer = await readFile(join(uploadsDir, filename));
-    const base64 = buffer.toString("base64");
-
-    // Detect media type from extension
-    const ext = filename.split(".").pop()?.toLowerCase() ?? "";
-    const mediaTypeMap: Record<string, "image/jpeg" | "image/png" | "image/gif" | "image/webp"> = {
-      jpg: "image/jpeg",
-      jpeg: "image/jpeg",
-      png: "image/png",
-      gif: "image/gif",
-      webp: "image/webp",
-    };
-    const mediaType = mediaTypeMap[ext] ?? "image/jpeg";
-
-    const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
-
-    const response = await client.messages.create({
-      model: "claude-haiku-4-5-20251001",
-      max_tokens: 100,
-      messages: [
-        {
-          role: "user",
-          content: [
-            {
-              type: "image",
-              source: { type: "base64", media_type: mediaType, data: base64 },
-            },
-            {
-              type: "text",
-              text: `This image should contain a handwritten 5-digit number: ${expectedCode}.\nLook carefully for any handwritten digits in the image. Note: handwritten "1" often looks like "7" and vice versa – read carefully.\nReply with JSON only: {"detected": "<5-digit code or null>", "match": true/false, "reason": "<brief reason in German if match is false, else null>"}.\nPossible reasons (pick the most fitting, keep it short): "Kein Code sichtbar", "Bild zu unscharf", "Code verdeckt oder abgeschnitten", "Schrift nicht lesbar", "Falscher Code sichtbar: <detected>", "Bild zu dunkel", "Kein handgeschriebener Code gefunden".`,
-            },
-          ],
-        },
-      ],
-    });
-
-    const text = response.content[0].type === "text" ? response.content[0].text : "";
-
-    // Erkennung von Content-Policy-Ablehnungen
-    const policyKeywords = ["I'm unable", "I cannot", "I can't", "inappropriate", "violates", "policy", "explicit", "sorry, I"];
-    const isRefusal = !text.includes("{") && policyKeywords.some((kw) => text.toLowerCase().includes(kw.toLowerCase()));
-    if (isRefusal) {
-      return NextResponse.json({ detected: null, match: false, error: "policy" });
-    }
-
-    const jsonMatch = text.match(/\{[\s\S]*\}/);
-    if (!jsonMatch) {
-      return NextResponse.json({ detected: null, match: false });
-    }
-
-    const result = JSON.parse(jsonMatch[0]);
-    const detected: string | null = result.detected ?? null;
-
-    // Fuzzy-Match: häufig verwechselte Ziffern (1↔7, 0↔6) als Treffer werten
-    const fuzzyMatch = (a: string, b: string): boolean => {
-      if (a === b) return true;
-      if (a.length !== b.length) return false;
-      const similar: Record<string, string> = { "1": "7", "7": "1", "0": "6", "6": "0" };
-      return a.split("").every((ch, i) => ch === b[i] || similar[ch] === b[i]);
-    };
-
-    const isMatch = result.match === true || (detected !== null && fuzzyMatch(detected, expectedCode));
-
-    return NextResponse.json({
-      detected,
-      match: isMatch,
-      reason: isMatch ? null : (result.reason ?? null),
-    });
-  } catch (err) {
-    console.error("verify-kontrolle error:", err);
+  const result = await verifyKontrolleCodeDetailed(imageUrl, expectedCode);
+  if (result === null) {
     return NextResponse.json({ detected: null, match: false, error: true });
   }
+
+  return NextResponse.json(result);
 }

--- a/src/app/components/StatsMain.tsx
+++ b/src/app/components/StatsMain.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 import { prisma } from "@/lib/prisma";
-import { formatDuration, formatDateTime, formatTime, formatHours, formatMs, toDateLocale, APP_TZ, mapAnforderungStatus, mapVerifikationStatus, getMidnightToday, getWeekStart, getMonthStart, tzDateParts, midnightInTZ } from "@/lib/utils";
+import { formatDuration, formatDateTime, formatTime, formatHours, formatMs, toDateLocale, APP_TZ, mapAnforderungStatus, mapVerifikationStatus, getMidnightToday, getWeekStart, getMonthStart, tzDateParts, midnightInTZ, buildPairs, interruptionPauseMs, type ReinigungSettings } from "@/lib/utils";
 import { getKombinierterPill } from "@/lib/kontrollePills";
 import CalendarExpand from "./CalendarExpand";
 import { type CalendarMonthData, type CalendarDayData } from "./CalendarContainer";
@@ -12,7 +12,7 @@ import { getTranslations, getLocale } from "next-intl/server";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
-type Entry = { id: string; type: string; startTime: Date; imageUrl: string | null; note: string | null; orgasmusArt?: string | null; kontrollCode?: string | null; verifikationStatus?: string | null };
+type Entry = { id: string; type: string; startTime: Date; imageUrl: string | null; note: string | null; orgasmusArt?: string | null; kontrollCode?: string | null; verifikationStatus?: string | null; oeffnenGrund?: string | null };
 type WearPair = { start: Date; end: Date };
 type CompletedPair = { verschluss: Entry; oeffnen: Entry; durationMs: number };
 type Vorgabe = {
@@ -26,21 +26,6 @@ type Vorgabe = {
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-function buildCompletedPairs(entries: Entry[]): CompletedPair[] {
-  const asc = [...entries].sort((a, b) => a.startTime.getTime() - b.startTime.getTime());
-  const pairs: CompletedPair[] = [];
-  let pending: Entry | null = null;
-  for (const e of asc) {
-    if (e.type === "VERSCHLUSS") {
-      if (pending) pairs.push({ verschluss: pending, oeffnen: { ...pending, type: "SYNTHETIC" }, durationMs: 0 });
-      pending = e;
-    } else if (e.type === "OEFFNEN" && pending) {
-      pairs.push({ verschluss: pending, oeffnen: e, durationMs: e.startTime.getTime() - pending.startTime.getTime() });
-      pending = null;
-    }
-  }
-  return pairs;
-}
 
 function buildWearPairs(entries: Entry[], now: Date): WearPair[] {
   const asc = [...entries]
@@ -160,12 +145,18 @@ export default async function StatsMain({ userId, heading, backHref, backLabel }
   const dl = toDateLocale(await getLocale());
   const now = new Date();
 
-  const [entries, vorgaben, kontrollen, sperrzeiten] = await Promise.all([
+  const [entries, vorgaben, kontrollen, sperrzeiten, userSettings] = await Promise.all([
     prisma.entry.findMany({ where: { userId }, orderBy: { startTime: "asc" } }),
     prisma.trainingVorgabe.findMany({ where: { userId }, orderBy: { gueltigAb: "desc" } }),
     prisma.kontrollAnforderung.findMany({ where: { userId }, orderBy: { createdAt: "desc" }, include: { entry: true } }),
     prisma.verschlussAnforderung.findMany({ where: { userId, art: "SPERRZEIT" } }),
+    prisma.user.findUnique({ where: { id: userId }, select: { reinigungErlaubt: true, reinigungMaxMinuten: true } }),
   ]);
+
+  const reinigung: ReinigungSettings = {
+    erlaubt: userSettings?.reinigungErlaubt ?? false,
+    maxMinuten: userSettings?.reinigungMaxMinuten ?? 15,
+  };
 
   const linkedEntryIds = new Set(kontrollen.map(k => k.entryId).filter(Boolean));
   const allPruefungen = entries.filter(e => e.type === "PRUEFUNG");
@@ -193,7 +184,13 @@ export default async function StatsMain({ userId, heading, backHref, backLabel }
     })),
   ].sort((a, b) => b.time.getTime() - a.time.getTime());
 
-  const allPairs = buildCompletedPairs(entries);
+  const allPairs = buildPairs(entries, [], reinigung)
+    .filter(p => p.oeffnen !== null)
+    .map(p => ({
+      verschluss: p.verschluss,
+      oeffnen: p.oeffnen!,
+      durationMs: p.oeffnen!.startTime.getTime() - p.verschluss.startTime.getTime() - interruptionPauseMs(p.interruptions),
+    }));
   const completed = allPairs.filter((p) => p.durationMs > 0);
   const totalMs = completed.reduce((s, p) => s + p.durationMs, 0);
 

--- a/src/data/changelog.json
+++ b/src/data/changelog.json
@@ -1,5 +1,18 @@
 [
   {
+    "version": "2.0.8",
+    "date": "2026-03-31",
+    "changes": [
+      { "type": "fix", "text": "Sicherheit: Upload-Route prüft Dateipfad via resolve() statt String-Matching; Zugriffsschutz auf eigene Dateien (IDOR)" },
+      { "type": "fix", "text": "Sicherheit: PATCH-Einträge und Admin-Einträge in prisma.$transaction (TOCTOU-Schutz)" },
+      { "type": "fix", "text": "Sicherheit: Admin-Vorgaben-Route gibt 404 zurück wenn Vorgabe nicht existiert" },
+      { "type": "fix", "text": "Sicherheit: verify-kontrolle-Route mit per-User-Rate-Limiting (max. 10 Anfragen/Minute)" },
+      { "type": "fix", "text": "Timezone: toDatetimeLocal() verwendet APP_TZ (Europe/Zurich) statt UTC" },
+      { "type": "fix", "text": "Statistik: buildCompletedPairs verwendet Reinigungsunterbrechungen korrekt (canonical buildPairs)" },
+      { "type": "fix", "text": "Performance: Login-Attempts-Map bereinigt abgelaufene Einträge alle 30 Minuten" }
+    ]
+  },
+  {
     "version": "2.0.7",
     "date": "2026-03-29",
     "changes": [

--- a/src/lib/login-attempts.ts
+++ b/src/lib/login-attempts.ts
@@ -2,6 +2,14 @@
 
 const loginAttempts = new Map<string, { failures: number; blockedUntil: Date | null }>();
 
+// Evict expired entries every 30 min to prevent unbounded memory growth
+setInterval(() => {
+  const now = new Date();
+  for (const [key, entry] of loginAttempts) {
+    if (!entry.blockedUntil || entry.blockedUntil <= now) loginAttempts.delete(key);
+  }
+}, 30 * 60 * 1000);
+
 export function checkRateLimit(username: string): boolean {
   const entry = loginAttempts.get(username);
   if (!entry) return true;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -381,6 +381,12 @@ export function buildKontrolleItems(
 export function toDatetimeLocal(date: Date | string | null | undefined): string {
   if (!date) return "";
   const d = new Date(date);
-  const pad = (n: number) => String(n).padStart(2, "0");
-  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone: APP_TZ,
+    year: "numeric", month: "2-digit", day: "2-digit",
+    hour: "2-digit", minute: "2-digit", hour12: false,
+  }).formatToParts(d);
+  const get = (type: string) => parts.find(p => p.type === type)?.value ?? "00";
+  const hour = get("hour") === "24" ? "00" : get("hour");
+  return `${get("year")}-${get("month")}-${get("day")}T${hour}:${get("minute")}`;
 }

--- a/src/lib/verifyCode.ts
+++ b/src/lib/verifyCode.ts
@@ -17,15 +17,21 @@ function fuzzyMatch(a: string, b: string): boolean {
   return a.split("").every((ch, i) => ch === b[i] || similar[ch] === b[i]);
 }
 
+export type VerifyDetailedResult = {
+  detected: string | null;
+  match: boolean;
+  reason: string | null;
+  error?: "policy" | true;
+};
+
 /**
- * Runs the Claude Vision check for a handwritten Kontrolle code.
- * Returns "ai" if the code matches, null otherwise (or on any error).
- * Reads the image from the local uploads directory.
+ * Runs the Claude Vision check and returns the full result (detected code, match, reason).
+ * Returns null on read/API errors.
  */
-export async function verifyKontrolleCode(
+export async function verifyKontrolleCodeDetailed(
   imageUrl: string,
   expectedCode: string
-): Promise<"ai" | null> {
+): Promise<VerifyDetailedResult | null> {
   try {
     const filename = basename(imageUrl);
     if (!filename || filename.includes("..") || filename.includes("/")) return null;
@@ -56,17 +62,28 @@ export async function verifyKontrolleCode(
     const text = response.content[0].type === "text" ? response.content[0].text : "";
     const policyKeywords = ["I'm unable", "I cannot", "I can't", "inappropriate", "violates", "policy", "explicit", "sorry, I"];
     if (!text.includes("{") && policyKeywords.some(kw => text.toLowerCase().includes(kw.toLowerCase()))) {
-      return null;
+      return { detected: null, match: false, reason: null, error: "policy" };
     }
 
     const jsonMatch = text.match(/\{[\s\S]*\}/);
-    if (!jsonMatch) return null;
+    if (!jsonMatch) return { detected: null, match: false, reason: null };
 
     const result = JSON.parse(jsonMatch[0]);
     const detected: string | null = result.detected ?? null;
     const isMatch = result.match === true || (detected !== null && fuzzyMatch(detected, expectedCode));
-    return isMatch ? "ai" : null;
+    return { detected, match: isMatch, reason: isMatch ? null : (result.reason ?? null) };
   } catch {
     return null;
   }
+}
+
+/**
+ * Convenience wrapper: returns "ai" if match, null otherwise.
+ */
+export async function verifyKontrolleCode(
+  imageUrl: string,
+  expectedCode: string
+): Promise<"ai" | null> {
+  const result = await verifyKontrolleCodeDetailed(imageUrl, expectedCode);
+  return result?.match ? "ai" : null;
 }


### PR DESCRIPTION
## Summary
- **Security**: uploads path traversal fix (resolve+sep) + IDOR protection (ownership check)
- **Security**: admin entries + entries[id] PATCH/DELETE wrapped in `prisma.$transaction` (TOCTOU)
- **Security**: admin vorgaben[id] 404-guard before PATCH/DELETE
- **Security**: verify-kontrolle per-user rate limiting (10 req/60s) + reuse `verifyKontrolleCodeDetailed()`
- **Timezone**: `toDatetimeLocal()` now uses `Intl` with `APP_TZ` instead of UTC `getHours()`
- **Logic**: `StatsMain.buildCompletedPairs` replaced with canonical `buildPairs()` (supports reinigung interruptions)
- **Memory**: `login-attempts.ts` cleans up expired entries every 30 min

## Test plan
- [ ] Upload a file and verify it's accessible only to its owner
- [ ] Edit an entry's startTime and verify temporal ordering is enforced
- [ ] Verify VERSCHLUSS/OEFFNEN create from admin panel still works atomically
- [ ] Edit entries datetime field in Switzerland timezone and verify correct value
- [ ] Stats page shows correct pair durations when reinigung interruptions exist
- [ ] verify-kontrolle returns 429 after 10 rapid requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)