### PR TITLE
feat: Numbered Seal – Siegel-Nummer beim Verschluss (v2.1.0)

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -133,7 +133,12 @@
   },
   "lockForm": {
     "title": "Verschluss erfassen",
-    "saveBtn": "Verschluss speichern"
+    "saveBtn": "Verschluss speichern",
+    "sealNumber": "Siegel-Nummer (optional)",
+    "sealNumberHint": "5–8 Ziffern",
+    "sealDetecting": "Nummer wird erkannt…",
+    "sealDetected": "Erkannt: {code}",
+    "sealNotDetected": "Nicht erkannt"
   },
   "openForm": {
     "title": "Öffnung erfassen",

--- a/messages/en.json
+++ b/messages/en.json
@@ -133,7 +133,12 @@
   },
   "lockForm": {
     "title": "Log lock",
-    "saveBtn": "Save lock"
+    "saveBtn": "Save lock",
+    "sealNumber": "Seal number (optional)",
+    "sealNumberHint": "5–8 digits",
+    "sealDetecting": "Detecting number…",
+    "sealDetected": "Detected: {code}",
+    "sealNotDetected": "Not detected"
   },
   "openForm": {
     "title": "Log opening",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kg-app",
-  "version": "2.0.8",
+  "version": "2.1.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/admin/users/[id]/aktionen/pruefung/PruefungForm.tsx
+++ b/src/app/admin/users/[id]/aktionen/pruefung/PruefungForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { ClipboardCheck, Loader2 } from "lucide-react";
@@ -9,22 +9,63 @@ import { compressImage } from "@/lib/compressImage";
 import ImageViewer from "@/app/components/ImageViewer";
 import PhotoCapture from "@/app/components/PhotoCapture";
 
-const inputCls = "text-sm bg-surface-raised border border-border rounded-xl px-3 py-2 text-foreground placeholder:text-foreground-faint focus:outline-none focus:ring-2 focus:ring-foreground-muted";
+const inputCls = "w-full bg-surface-raised border border-border rounded-xl px-4 py-3.5 text-base text-foreground focus:outline-none focus:ring-2 focus:ring-foreground-muted focus:border-transparent transition";
 
 export default function PruefungForm({ userId }: { userId: string }) {
   const router = useRouter();
+
   const [startTime, setStartTime] = useState(() => toDatetimeLocal(new Date()));
   const [note, setNote] = useState("");
+  const [kontrollCode, setKontrollCode] = useState("");
   const [imageUrl, setImageUrl] = useState("");
   const [imageExifTime, setImageExifTime] = useState("");
   const [imagePreview, setImagePreview] = useState("");
   const [uploading, setUploading] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
+  const [exifWarning, setExifWarning] = useState("");
+  const [verifyStatus, setVerifyStatus] = useState<"pending" | "match" | "mismatch" | "error" | "policy" | null>(null);
+  const [verifyReason, setVerifyReason] = useState<string | null>(null);
+  const [aiMatch, setAiMatch] = useState<boolean | null>(null);
+  const lastVerifiedKey = useRef<string>("");
+
+  useEffect(() => {
+    const key = `${kontrollCode}|${imageUrl}`;
+    if (kontrollCode.length >= 5 && kontrollCode.length <= 8 && imageUrl && key !== lastVerifiedKey.current) {
+      lastVerifiedKey.current = key;
+      setVerifyStatus("pending");
+      setVerifyReason(null);
+      setAiMatch(null);
+      fetch("/api/verify-kontrolle", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ imageUrl, expectedCode: kontrollCode }),
+      })
+        .then((r) => r.json())
+        .then((v) => {
+          if (v.error === "policy") {
+            setVerifyStatus("policy");
+          } else if (v.error) {
+            setVerifyStatus("error");
+          } else {
+            setVerifyStatus(v.match ? "match" : "mismatch");
+            setVerifyReason(v.reason ?? null);
+            setAiMatch(v.match ? true : false);
+          }
+        })
+        .catch(() => setVerifyStatus("error"));
+    }
+  }, [kontrollCode, imageUrl]);
 
   async function handleFile(file: File) {
     setUploading(true);
+    setExifWarning("");
     setImagePreview(URL.createObjectURL(file));
+    setError("");
+    setVerifyStatus(null);
+    setVerifyReason(null);
+    setAiMatch(null);
+
     const clientExifTime = file.lastModified ? new Date(file.lastModified).toISOString() : null;
     const compressed = await compressImage(file).catch(() => file);
     const fd = new FormData();
@@ -33,12 +74,21 @@ export default function PruefungForm({ userId }: { userId: string }) {
     const res = await fetch("/api/upload", { method: "POST", body: fd });
     const data = await res.json();
     setImageUrl(data.url);
+    setImagePreview(data.url);
     setImageExifTime(data.exifTime ?? "");
+
+    if (data.exifTime && startTime) {
+      const diff = Math.abs(new Date(data.exifTime).getTime() - new Date(startTime).getTime());
+      if (diff > 3600000) setExifWarning(`EXIF-Zeit weicht ${Math.round(diff / 3600000)}h ab`);
+    } else if (!data.exifTime) {
+      setExifWarning("Foto enthält keine EXIF-Zeitangabe");
+    }
     setUploading(false);
   }
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
+    if (!imageUrl) { setError("Foto ist bei Kontrolle zwingend"); return; }
     setLoading(true);
     setError("");
     const res = await fetch("/api/admin/entries", {
@@ -51,6 +101,8 @@ export default function PruefungForm({ userId }: { userId: string }) {
         note: note.trim() || undefined,
         imageUrl: imageUrl || undefined,
         imageExifTime: imageExifTime || undefined,
+        kontrollCode: kontrollCode || undefined,
+        verifikationStatus: aiMatch === true ? "ai" : undefined,
       }),
     });
     setLoading(false);
@@ -76,29 +128,26 @@ export default function PruefungForm({ userId }: { userId: string }) {
           <h1 className="text-base font-semibold text-foreground">Prüfung erfassen</h1>
         </div>
 
-        <form onSubmit={handleSubmit} className="flex flex-col gap-4 px-5 py-5">
-          <div className="flex flex-col gap-1">
-            <label className="text-xs text-foreground-faint">Zeitpunkt</label>
-            <input
-              type="datetime-local"
-              value={startTime}
-              onChange={(e) => setStartTime(e.target.value)}
-              className={inputCls}
-              required
-            />
+        <form onSubmit={handleSubmit} className="flex flex-col gap-5 px-5 py-5">
+          {/* Datum / Zeit */}
+          <div>
+            <label className="block text-xs font-semibold text-foreground-faint uppercase tracking-wider mb-2">Datum / Zeit *</label>
+            <input type="datetime-local" value={startTime} onChange={(e) => setStartTime(e.target.value)} required className={inputCls} />
           </div>
 
-          <div className="flex flex-col gap-1">
-            <label className="text-xs text-foreground-faint">Foto (optional)</label>
+          {/* Foto (zwingend) */}
+          <div>
+            <label className="block text-xs font-semibold text-foreground-faint uppercase tracking-wider mb-2">
+              Foto <span className="text-warn">*</span> <span className="text-foreground-faint normal-case font-normal">(zwingend)</span>
+            </label>
             {imagePreview ? (
               <div className="flex items-start gap-4">
-                <ImageViewer src={imagePreview} alt="Vorschau" width={80} height={80} className="w-20 h-20 rounded-xl object-cover" />
+                <ImageViewer src={imagePreview} alt="Vorschau" width={80} height={80} className="w-20 h-20 rounded-xl object-cover flex-shrink-0" />
                 <div className="flex flex-col gap-2 flex-1 pt-1">
-                  {imageExifTime && (
-                    <p className="text-xs text-foreground-faint">EXIF: {new Date(imageExifTime).toLocaleString()}</p>
-                  )}
+                  {imageExifTime && <p className="text-xs text-foreground-faint">EXIF: {new Date(imageExifTime).toLocaleString()}</p>}
+                  {exifWarning && !uploading && <p className="text-xs text-[var(--color-warn)] font-medium">⚠ {exifWarning}</p>}
                   <PhotoCapture onFile={handleFile} uploading={uploading} variant="orange" compact />
-                  <button type="button" onClick={() => { setImageUrl(""); setImagePreview(""); setImageExifTime(""); }}
+                  <button type="button" onClick={() => { setImageUrl(""); setImagePreview(""); setImageExifTime(""); setExifWarning(""); setVerifyStatus(null); setAiMatch(null); }}
                     className="text-xs text-warn hover:opacity-80 w-fit transition">
                     Foto entfernen
                   </button>
@@ -109,27 +158,63 @@ export default function PruefungForm({ userId }: { userId: string }) {
             )}
           </div>
 
-          <div className="flex flex-col gap-1">
-            <label className="text-xs text-foreground-faint">Notiz (optional)</label>
-            <textarea
-              value={note}
-              onChange={(e) => setNote(e.target.value)}
-              placeholder="Notiz (optional)"
-              rows={2}
-              className={`${inputCls} w-full resize-none`}
+          {/* Verifikationsstatus */}
+          {verifyStatus === "pending" && (
+            <p className="text-sm text-foreground-muted flex items-center gap-2">
+              <Loader2 size={14} className="animate-spin" /> Code wird im Bild geprüft…
+            </p>
+          )}
+          {verifyStatus === "match" && (
+            <p className="text-sm text-[var(--color-ok)] font-medium">✅ Code erkannt</p>
+          )}
+          {verifyStatus === "policy" && (
+            <div className="bg-surface-raised border border-border rounded-xl px-4 py-3">
+              <p className="text-sm text-foreground-muted font-medium">Bild konnte nicht geprüft werden</p>
+              <p className="text-xs text-foreground-faint mt-0.5">Das Bild entspricht nicht den Inhaltsrichtlinien – kann trotzdem gespeichert werden.</p>
+            </div>
+          )}
+          {verifyStatus === "mismatch" && (
+            <div className="bg-warn-bg border border-[var(--color-warn-border)] rounded-xl px-4 py-3">
+              <p className="text-sm text-[var(--color-warn-text)] font-medium">⚠ Code nicht erkannt</p>
+              {verifyReason && <p className="text-xs text-[var(--color-warn)] mt-0.5">{verifyReason}</p>}
+              <p className="text-xs text-[var(--color-warn)] mt-1">Code deutlich sichtbar im Foto zeigen – kann trotzdem gespeichert werden.</p>
+            </div>
+          )}
+
+          {/* Kontroll-Code */}
+          <div>
+            <label className="block text-xs font-semibold text-foreground-faint uppercase tracking-wider mb-2">
+              Kontroll-Code <span className="text-[var(--color-inspect)] normal-case font-normal">(muss im Foto erkennbar sein)</span>
+            </label>
+            <input
+              type="text"
+              value={kontrollCode}
+              onChange={(e) => { setKontrollCode(e.target.value.replace(/\D/g, "").slice(0, 8)); setVerifyStatus(null); setAiMatch(null); }}
+              maxLength={8}
+              placeholder="–"
+              className={`${inputCls} font-mono tracking-widest text-[var(--color-inspect)] font-bold text-xl`}
             />
           </div>
 
-          {error && <p className="text-xs text-warn">{error}</p>}
+          {/* Notiz */}
+          <div>
+            <label className="block text-xs font-semibold text-foreground-faint uppercase tracking-wider mb-2">Notiz (optional)</label>
+            <textarea value={note} onChange={(e) => setNote(e.target.value)} rows={3} className={`${inputCls} resize-none`} />
+          </div>
 
-          <button
-            type="submit"
-            disabled={loading || uploading}
-            className="flex items-center justify-center gap-2 text-sm font-medium text-[var(--btn-primary-text)] bg-[var(--btn-primary-bg)] hover:bg-[var(--btn-primary-hover)] rounded-xl px-4 py-3 disabled:opacity-50 transition"
-          >
-            {loading ? <Loader2 size={16} className="animate-spin" /> : <ClipboardCheck size={16} />}
-            {loading ? "Sende…" : "Prüfung erfassen"}
-          </button>
+          {error && <p className="text-sm text-warn bg-warn-bg border border-[var(--color-warn-border)] rounded-xl px-4 py-3">{error}</p>}
+
+          <div className="flex flex-col-reverse sm:flex-row gap-3 pt-1">
+            <button type="button" onClick={() => router.push(`/admin/users/${userId}/aktionen`)}
+              className="flex-1 text-sm text-foreground-muted border border-border rounded-xl py-3.5 hover:bg-surface-raised active:scale-[0.98] transition-all">
+              Abbrechen
+            </button>
+            <button type="submit" disabled={loading || uploading}
+              className="flex-1 bg-[var(--color-inspect)] text-white text-base font-semibold py-3.5 rounded-xl flex items-center justify-center gap-2 hover:opacity-90 active:scale-[0.98] disabled:opacity-50 transition-all">
+              {loading ? <Loader2 size={16} className="animate-spin" /> : <ClipboardCheck size={16} />}
+              {loading ? "Sende…" : "Prüfung erfassen"}
+            </button>
+          </div>
         </form>
       </div>
     </main>

--- a/src/app/admin/users/[id]/aktionen/verschluss/VerschlussForm.tsx
+++ b/src/app/admin/users/[id]/aktionen/verschluss/VerschlussForm.tsx
@@ -18,12 +18,15 @@ export default function VerschlussForm({ userId }: { userId: string }) {
   const [imageUrl, setImageUrl] = useState("");
   const [imageExifTime, setImageExifTime] = useState("");
   const [imagePreview, setImagePreview] = useState("");
+  const [sealNumber, setSealNumber] = useState("");
+  const [sealState, setSealState] = useState<"idle" | "detecting" | "detected" | "not-detected">("idle");
   const [uploading, setUploading] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
 
   async function handleFile(file: File) {
     setUploading(true);
+    setSealState("idle");
     setImagePreview(URL.createObjectURL(file));
     const clientExifTime = file.lastModified ? new Date(file.lastModified).toISOString() : null;
     const compressed = await compressImage(file).catch(() => file);
@@ -35,6 +38,29 @@ export default function VerschlussForm({ userId }: { userId: string }) {
     setImageUrl(data.url);
     setImageExifTime(data.exifTime ?? "");
     setUploading(false);
+
+    // Auto-detect seal number
+    setSealState("detecting");
+    try {
+      const detectRes = await fetch("/api/detect-seal", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ imageUrl: data.url }),
+      });
+      if (detectRes.ok) {
+        const { detected } = await detectRes.json() as { detected: string | null };
+        if (detected) {
+          setSealNumber(detected);
+          setSealState("detected");
+        } else {
+          setSealState("not-detected");
+        }
+      } else {
+        setSealState("not-detected");
+      }
+    } catch {
+      setSealState("not-detected");
+    }
   }
 
   async function handleSubmit(e: React.FormEvent) {
@@ -51,6 +77,7 @@ export default function VerschlussForm({ userId }: { userId: string }) {
         note: note.trim() || undefined,
         imageUrl: imageUrl || undefined,
         imageExifTime: imageExifTime || undefined,
+        kontrollCode: sealNumber.trim() || undefined,
       }),
     });
     setLoading(false);
@@ -98,7 +125,7 @@ export default function VerschlussForm({ userId }: { userId: string }) {
                     <p className="text-xs text-foreground-faint">EXIF: {new Date(imageExifTime).toLocaleString()}</p>
                   )}
                   <PhotoCapture onFile={handleFile} uploading={uploading} variant="emerald" compact />
-                  <button type="button" onClick={() => { setImageUrl(""); setImagePreview(""); setImageExifTime(""); }}
+                  <button type="button" onClick={() => { setImageUrl(""); setImagePreview(""); setImageExifTime(""); setSealState("idle"); }}
                     className="text-xs text-warn hover:opacity-80 w-fit transition">
                     Foto entfernen
                   </button>
@@ -107,6 +134,23 @@ export default function VerschlussForm({ userId }: { userId: string }) {
             ) : (
               <PhotoCapture onFile={handleFile} uploading={uploading} variant="emerald" />
             )}
+          </div>
+
+          <div className="flex flex-col gap-1">
+            <label className="text-xs text-foreground-faint">Siegel-Nummer (optional)</label>
+            <input
+              type="text"
+              inputMode="numeric"
+              pattern="\d{5,8}"
+              maxLength={8}
+              value={sealNumber}
+              onChange={(e) => { setSealNumber(e.target.value.replace(/\D/g, "")); setSealState("idle"); }}
+              placeholder="5–8 Ziffern"
+              className={inputCls}
+            />
+            {sealState === "detecting" && <p className="text-xs text-foreground-faint">Nummer wird erkannt…</p>}
+            {sealState === "detected" && <p className="text-xs text-[var(--color-lock)]">Erkannt: {sealNumber}</p>}
+            {sealState === "not-detected" && !sealNumber && <p className="text-xs text-foreground-faint">Nicht erkannt</p>}
           </div>
 
           <div className="flex flex-col gap-1">

--- a/src/app/admin/users/[id]/eintraege/page.tsx
+++ b/src/app/admin/users/[id]/eintraege/page.tsx
@@ -65,6 +65,9 @@ export default async function AdminUserEintraegePage({ params }: { params: Promi
                 {e.orgasmusArt && (
                   <span className="text-xs text-[var(--color-orgasm)] font-medium">{e.orgasmusArt}</span>
                 )}
+                {e.type === "VERSCHLUSS" && e.kontrollCode && (
+                  <span className="text-xs text-[var(--color-lock)] font-mono tabular-nums">#{e.kontrollCode}</span>
+                )}
                 {e.note && (
                   <span className="text-xs text-foreground-faint italic truncate min-w-0">„{e.note}"</span>
                 )}

--- a/src/app/api/admin/entries/route.ts
+++ b/src/app/api/admin/entries/route.ts
@@ -13,7 +13,7 @@ export async function POST(req: NextRequest) {
   }
 
   const body = await req.json();
-  const { userId, type, startTime, note, oeffnenGrund, orgasmusArt, imageUrl, imageExifTime } = body;
+  const { userId, type, startTime, note, oeffnenGrund, orgasmusArt, imageUrl, imageExifTime, kontrollCode } = body;
 
   if (!userId) return NextResponse.json({ error: "userId is required" }, { status: 400 });
   if (!startTime) return NextResponse.json({ error: "startTime is required" }, { status: 400 });
@@ -70,6 +70,7 @@ export async function POST(req: NextRequest) {
           orgasmusArt: orgasmusArt || null,
           imageUrl: imageUrl || null,
           imageExifTime: imageExifTime ? new Date(imageExifTime) : null,
+          kontrollCode: kontrollCode || null,
         },
       });
     });

--- a/src/app/api/admin/kontrolle/route.ts
+++ b/src/app/api/admin/kontrolle/route.ts
@@ -32,8 +32,9 @@ export async function POST(req: NextRequest) {
     data: { withdrawnAt: new Date() },
   });
 
-  // Neue Anforderung erstellen
-  const code = String(Math.floor(10000 + Math.random() * 90000));
+  // Siegel-Nummer des aktiven Verschlusses verwenden, sonst Zufallscode
+  const sealCode = latest.kontrollCode && /^\d{5,8}$/.test(latest.kontrollCode) ? latest.kontrollCode : null;
+  const code = sealCode ?? String(Math.floor(10000 + Math.random() * 90000));
   const hours = typeof deadlineH === "number" && deadlineH > 0 ? deadlineH : 4;
   const deadline = new Date(Date.now() + hours * 60 * 60 * 1000);
 
@@ -53,6 +54,10 @@ export async function POST(req: NextRequest) {
     hour: "2-digit", minute: "2-digit", timeZone: "Europe/Zurich",
   });
 
+  const codeLabel = sealCode
+    ? "Deine Siegel-Nummer (muss auf dem Foto erkennbar sein):"
+    : "Dein Kontroll-Code (muss auf dem Foto erkennbar sein):";
+
   await sendMail(
     user.email,
     "KG-Tracker – Kontrolle angefordert",
@@ -62,7 +67,7 @@ export async function POST(req: NextRequest) {
       <p>Hallo ${user.username},</p>
       <p>Es wurde eine Kontrolle angefordert. Bitte erstelle innert der nächsten ${hours} Stunde${hours === 1 ? "" : "n"} einen Kontroll-Eintrag mit Foto.</p>
       ${kommentarHtml}
-      <p><strong>Dein Kontroll-Code (muss auf dem Foto erkennbar sein):</strong></p>
+      <p><strong>${codeLabel}</strong></p>
       <div style="font-size:48px;font-weight:bold;letter-spacing:12px;color:#f97316;text-align:center;padding:24px;background:#fff7ed;border-radius:12px;margin:16px 0">${code}</div>
       <p><strong>Frist:</strong> ${deadlineStr}</p>
       <p>

--- a/src/app/api/detect-seal/route.ts
+++ b/src/app/api/detect-seal/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { detectSealNumber } from "@/lib/verifyCode";
+
+const rateLimitMap = new Map<string, { count: number; resetAt: number }>();
+const RATE_WINDOW_MS = 60_000;
+const RATE_MAX = 10;
+
+function checkRateLimit(userId: string): boolean {
+  const now = Date.now();
+  const entry = rateLimitMap.get(userId);
+  if (!entry || entry.resetAt < now) {
+    rateLimitMap.set(userId, { count: 1, resetAt: now + RATE_WINDOW_MS });
+    return true;
+  }
+  if (entry.count >= RATE_MAX) return false;
+  entry.count++;
+  return true;
+}
+
+export async function POST(req: NextRequest) {
+  const session = await auth();
+  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  if (!checkRateLimit(session.user.id)) {
+    return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+  }
+
+  const { imageUrl } = await req.json();
+  if (!imageUrl) return NextResponse.json({ error: "imageUrl required" }, { status: 400 });
+
+  const detected = await detectSealNumber(imageUrl);
+  return NextResponse.json({ detected });
+}

--- a/src/app/dashboard/VerschlussForm.tsx
+++ b/src/app/dashboard/VerschlussForm.tsx
@@ -15,6 +15,7 @@ interface Props {
     imageUrl?: string | null;
     imageExifTime?: string | null;
     note?: string | null;
+    kontrollCode?: string | null;
   };
   mobileDesktopMode?: boolean;
 }
@@ -31,6 +32,8 @@ export default function VerschlussForm({ initial, mobileDesktopMode }: Props) {
   const [imageUrl, setImageUrl] = useState(initial?.imageUrl ?? "");
   const [imageExifTime, setImageExifTime] = useState(initial?.imageExifTime ?? "");
   const [imagePreview, setImagePreview] = useState(initial?.imageUrl ?? "");
+  const [sealNumber, setSealNumber] = useState(initial?.kontrollCode ?? "");
+  const [sealState, setSealState] = useState<"idle" | "detecting" | "detected" | "not-detected">("idle");
   const [uploading, setUploading] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState("");
@@ -39,11 +42,10 @@ export default function VerschlussForm({ initial, mobileDesktopMode }: Props) {
   async function handleFile(file: File) {
     setUploading(true);
     setExifWarning("");
+    setSealState("idle");
     setImagePreview(URL.createObjectURL(file));
 
-    // iOS Safari strips EXIF — read lastModified BEFORE compression (metadata stays intact)
     const clientExifTime = file.lastModified ? new Date(file.lastModified).toISOString() : null;
-
     const compressed = await compressImage(file).catch(() => file);
 
     const fd = new FormData();
@@ -64,6 +66,29 @@ export default function VerschlussForm({ initial, mobileDesktopMode }: Props) {
       setExifWarning(t("exifMissing"));
     }
     setUploading(false);
+
+    // Auto-detect seal number from photo
+    setSealState("detecting");
+    try {
+      const detectRes = await fetch("/api/detect-seal", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ imageUrl: data.url }),
+      });
+      if (detectRes.ok) {
+        const { detected } = await detectRes.json() as { detected: string | null };
+        if (detected) {
+          setSealNumber(detected);
+          setSealState("detected");
+        } else {
+          setSealState("not-detected");
+        }
+      } else {
+        setSealState("not-detected");
+      }
+    } catch {
+      setSealState("not-detected");
+    }
   }
 
   async function handleSubmit(e: React.FormEvent) {
@@ -82,6 +107,7 @@ export default function VerschlussForm({ initial, mobileDesktopMode }: Props) {
           imageUrl: imageUrl || null,
           imageExifTime: imageExifTime || null,
           note: note || null,
+          kontrollCode: sealNumber.trim() || null,
         }),
       }
     );
@@ -128,7 +154,7 @@ export default function VerschlussForm({ initial, mobileDesktopMode }: Props) {
                 <p className="text-xs text-[var(--color-warn)] font-medium">⚠ {exifWarning}</p>
               )}
               <PhotoCapture onFile={handleFile} uploading={uploading} variant="emerald" compact mobileDesktopMode={mobileDesktopMode} />
-              <button type="button" onClick={() => { setImageUrl(""); setImagePreview(""); setImageExifTime(""); setExifWarning(""); }}
+              <button type="button" onClick={() => { setImageUrl(""); setImagePreview(""); setImageExifTime(""); setExifWarning(""); setSealState("idle"); }}
                 className="text-xs text-warn hover:opacity-80 w-fit transition">
                 {t("removePhoto")}
               </button>
@@ -137,6 +163,31 @@ export default function VerschlussForm({ initial, mobileDesktopMode }: Props) {
         ) : (
           <PhotoCapture onFile={handleFile} uploading={uploading} variant="emerald" mobileDesktopMode={mobileDesktopMode} />
         )}
+      </Field>
+
+      {/* Siegel-Nummer */}
+      <Field label={tForm("sealNumber")}>
+        <div className="flex flex-col gap-1.5">
+          <input
+            type="text"
+            inputMode="numeric"
+            pattern="\d{5,8}"
+            maxLength={8}
+            value={sealNumber}
+            onChange={(e) => { setSealNumber(e.target.value.replace(/\D/g, "")); setSealState("idle"); }}
+            placeholder={tForm("sealNumberHint")}
+            className={inputCls}
+          />
+          {sealState === "detecting" && (
+            <p className="text-xs text-foreground-faint">{tForm("sealDetecting")}</p>
+          )}
+          {sealState === "detected" && (
+            <p className="text-xs text-[var(--color-lock)]">{tForm("sealDetected", { code: sealNumber })}</p>
+          )}
+          {sealState === "not-detected" && !sealNumber && (
+            <p className="text-xs text-foreground-faint">{tForm("sealNotDetected")}</p>
+          )}
+        </div>
       </Field>
 
       {/* Notiz */}

--- a/src/app/dashboard/edit/[id]/page.tsx
+++ b/src/app/dashboard/edit/[id]/page.tsx
@@ -47,7 +47,8 @@ export default async function EditEntryPage({
       {entry.type === "VERSCHLUSS" && (
         <VerschlussForm initial={{
           id: entry.id, startTime: entry.startTime.toISOString(),
-          imageUrl: entry.imageUrl, imageExifTime: entry.imageExifTime?.toISOString() ?? null, note: entry.note,
+          imageUrl: entry.imageUrl, imageExifTime: entry.imageExifTime?.toISOString() ?? null,
+          note: entry.note, kontrollCode: entry.kontrollCode,
         }} mobileDesktopMode={mobileDesktopMode} />
       )}
       {entry.type === "PRUEFUNG" && (

--- a/src/app/dashboard/eintraege/page.tsx
+++ b/src/app/dashboard/eintraege/page.tsx
@@ -63,6 +63,9 @@ export default async function EintraegePage() {
                 {e.orgasmusArt && (
                   <span className="text-xs text-[var(--color-orgasm)] font-medium">{e.orgasmusArt}</span>
                 )}
+                {e.type === "VERSCHLUSS" && e.kontrollCode && (
+                  <span className="text-xs text-[var(--color-lock)] font-mono tabular-nums">#{e.kontrollCode}</span>
+                )}
                 {e.note && (
                   <span className="text-xs text-foreground-faint italic truncate min-w-0">„{e.note}"</span>
                 )}

--- a/src/data/changelog.json
+++ b/src/data/changelog.json
@@ -1,5 +1,13 @@
 [
   {
+    "version": "2.1.0",
+    "date": "2026-03-31",
+    "changes": [
+      { "type": "feat", "text": "Numbered Seal: Beim Verschluss kann eine Siegel-Nummer (5–8 Ziffern) hinterlegt werden – wird automatisch aus dem Foto erkannt (Claude Vision)" },
+      { "type": "feat", "text": "Numbered Seal: Kontrollanforderungen verwenden die Siegel-Nummer des aktiven Verschlusses als Kontroll-Code (statt Zufallscode)" }
+    ]
+  },
+  {
     "version": "2.0.8",
     "date": "2026-03-31",
     "changes": [

--- a/src/lib/verifyCode.ts
+++ b/src/lib/verifyCode.ts
@@ -87,3 +87,48 @@ export async function verifyKontrolleCode(
   const result = await verifyKontrolleCodeDetailed(imageUrl, expectedCode);
   return result?.match ? "ai" : null;
 }
+
+/**
+ * Tries to detect a 5–8 digit numbered seal from an image.
+ * Returns the detected number string, or null if none found.
+ */
+export async function detectSealNumber(imageUrl: string): Promise<string | null> {
+  try {
+    const filename = basename(imageUrl);
+    if (!filename || filename.includes("..") || filename.includes("/")) return null;
+
+    const buffer = await readFile(join(process.cwd(), "data", "uploads", filename));
+    const base64 = buffer.toString("base64");
+    const ext = filename.split(".").pop()?.toLowerCase() ?? "";
+    const mediaType = MEDIA_TYPES[ext] ?? "image/jpeg";
+
+    const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+    const response = await client.messages.create({
+      model: "claude-haiku-4-5-20251001",
+      max_tokens: 50,
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "image", source: { type: "base64", media_type: mediaType, data: base64 } },
+            {
+              type: "text",
+              text: `Look for a numbered seal, security seal, or any label with a printed or stamped number in this image. Report the 5–8 digit number if you find one.\nReply with JSON only: {"detected": "<5-8 digit number or null>"}. If no clear number is found, use null.`,
+            },
+          ],
+        },
+      ],
+    });
+
+    const text = response.content[0].type === "text" ? response.content[0].text : "";
+    const jsonMatch = text.match(/\{[\s\S]*\}/);
+    if (!jsonMatch) return null;
+    const result = JSON.parse(jsonMatch[0]);
+    const detected = result.detected;
+    if (!detected || typeof detected !== "string") return null;
+    if (!/^\d{5,8}$/.test(detected)) return null;
+    return detected;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- **Verschluss-Formular** (User & Admin): neues optionales Feld „Siegel-Nummer" (5–8 Ziffern)
- **Auto-Erkennung**: nach Foto-Upload → `POST /api/detect-seal` → Claude Vision erkennt Nummer automatisch und füllt Feld vor; User kann manuell korrigieren/leer lassen
- **KontrollAnforderung**: wenn aktiver Verschluss eine Siegel-Nummer hat, wird diese als Code verwendet (statt Zufallscode); E-Mail-Text passt sich an („Siegel-Nummer" statt „Kontroll-Code")
- **Eintrags-Listen** (User + Admin): Siegel-Nummer wird beim Verschluss als `#XXXXX` angezeigt
- **Edit-Seite**: Siegel-Nummer wird beim Bearbeiten eines Verschluss-Eintrags vorgeladen

## New API
- `POST /api/detect-seal` — auth-geschützt, rate-limited (10/min), gibt `{ detected: string | null }` zurück

## Test plan
- [ ] Verschluss ohne Foto erstellen → Siegel-Nummer-Feld leer, kein Fehler
- [ ] Verschluss mit Foto eines nummerierten Siegels → Nummer wird automatisch erkannt + vorausgefüllt
- [ ] Siegel-Nummer manuell eingeben → wird korrekt gespeichert
- [ ] KontrollAnforderung für User mit Siegel → E-Mail zeigt Siegel-Nummer (nicht Zufallscode)
- [ ] KontrollAnforderung für User ohne Siegel → E-Mail zeigt Zufallscode wie bisher
- [ ] Kontrolle (PRUEFUNG) mit Siegel-Nummer → Verifikation schlägt fehl wenn Nummer nicht im Foto

🤖 Generated with [Claude Code](https://claude.com/claude-code)