### PR TITLE
feat: OAuth 2.0 Authorization Server for MCP — Claude Mobile support (v4.18.6)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kg-app",
-  "version": "4.18.5",
+  "version": "4.18.6",
   "private": true,
   "license": "SEE LICENSE IN LICENSE.md",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kg-app",
-  "version": "4.18.7",
+  "version": "4.18.8",
   "private": true,
   "license": "SEE LICENSE IN LICENSE.md",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kg-app",
-  "version": "4.18.6",
+  "version": "4.18.7",
   "private": true,
   "license": "SEE LICENSE IN LICENSE.md",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kg-app",
-  "version": "4.18.8",
+  "version": "4.18.9",
   "private": true,
   "license": "SEE LICENSE IN LICENSE.md",
   "scripts": {

--- a/prisma/migrations/20260527203045_oauth_authorization_server/migration.sql
+++ b/prisma/migrations/20260527203045_oauth_authorization_server/migration.sql
@@ -1,0 +1,57 @@
+-- CreateTable
+CREATE TABLE "OAuthClient" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "clientId" TEXT NOT NULL,
+    "clientName" TEXT NOT NULL,
+    "redirectUris" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- CreateTable
+CREATE TABLE "OAuthCode" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "code" TEXT NOT NULL,
+    "clientId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "redirectUri" TEXT NOT NULL,
+    "scopes" TEXT NOT NULL,
+    "codeChallenge" TEXT NOT NULL,
+    "codeChallengeMethod" TEXT NOT NULL DEFAULT 'S256',
+    "expiresAt" DATETIME NOT NULL,
+    "usedAt" DATETIME,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "OAuthCode_clientId_fkey" FOREIGN KEY ("clientId") REFERENCES "OAuthClient" ("clientId") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "OAuthToken" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "tokenHash" TEXT NOT NULL,
+    "clientId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "scopes" TEXT NOT NULL,
+    "expiresAt" DATETIME NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "OAuthToken_clientId_fkey" FOREIGN KEY ("clientId") REFERENCES "OAuthClient" ("clientId") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "OAuthClient_clientId_key" ON "OAuthClient"("clientId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "OAuthCode_code_key" ON "OAuthCode"("code");
+
+-- CreateIndex
+CREATE INDEX "OAuthCode_code_idx" ON "OAuthCode"("code");
+
+-- CreateIndex
+CREATE INDEX "OAuthCode_expiresAt_idx" ON "OAuthCode"("expiresAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "OAuthToken_tokenHash_key" ON "OAuthToken"("tokenHash");
+
+-- CreateIndex
+CREATE INDEX "OAuthToken_tokenHash_idx" ON "OAuthToken"("tokenHash");
+
+-- CreateIndex
+CREATE INDEX "OAuthToken_expiresAt_idx" ON "OAuthToken"("expiresAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -273,3 +273,54 @@ model AppMeta {
   value     String
   updatedAt DateTime @updatedAt
 }
+
+// ── OAuth 2.0 Authorization Server ──────────────────────────────────────────
+// Enables Claude Mobile / Claude Desktop to authenticate to the MCP server
+// via OAuth 2.0 Authorization Code + PKCE instead of a static bearer token.
+
+// Registered OAuth clients (e.g. Claude Desktop, Claude Mobile).
+// Dynamic Client Registration (RFC 7591) creates rows here automatically.
+model OAuthClient {
+  id           String   @id @default(cuid())
+  clientId     String   @unique
+  clientName   String
+  redirectUris String   // JSON array of allowed redirect URIs
+  createdAt    DateTime @default(now())
+
+  codes  OAuthCode[]
+  tokens OAuthToken[]
+}
+
+// Short-lived authorization codes (10 min). Exchanged once for an access token.
+model OAuthCode {
+  id                  String      @id @default(cuid())
+  code                String      @unique
+  clientId            String
+  client              OAuthClient @relation(fields: [clientId], references: [clientId], onDelete: Cascade)
+  userId              String
+  redirectUri         String
+  scopes              String      // space-separated list, e.g. "read"
+  codeChallenge       String      // PKCE S256 challenge
+  codeChallengeMethod String      @default("S256")
+  expiresAt           DateTime
+  usedAt              DateTime?   // set when exchanged — single-use enforcement
+  createdAt           DateTime    @default(now())
+
+  @@index([code])
+  @@index([expiresAt])
+}
+
+// Long-lived access tokens issued to MCP clients.
+model OAuthToken {
+  id        String      @id @default(cuid())
+  tokenHash String      @unique // SHA-256 hex of the raw token — never store plaintext
+  clientId  String
+  client    OAuthClient @relation(fields: [clientId], references: [clientId], onDelete: Cascade)
+  userId    String
+  scopes    String      // space-separated list, e.g. "read"
+  expiresAt DateTime    // 1 year
+  createdAt DateTime    @default(now())
+
+  @@index([tokenHash])
+  @@index([expiresAt])
+}

--- a/src/app/.well-known/oauth-authorization-server/route.ts
+++ b/src/app/.well-known/oauth-authorization-server/route.ts
@@ -7,7 +7,10 @@ import { OAUTH_SUPPORTED_SCOPES, OAUTH_SUPPORTED_GRANT_TYPES, OAUTH_CODE_CHALLEN
  * Required by the MCP spec so clients can auto-discover endpoints.
  */
 export async function GET(req: Request) {
-  const base = new URL(req.url).origin;
+  // Behind Traefik the internal URL is 0.0.0.0:3000 — use forwarded headers for the public origin.
+  const host = req.headers.get("x-forwarded-host") ?? req.headers.get("host") ?? new URL(req.url).host;
+  const proto = req.headers.get("x-forwarded-proto")?.split(",").at(-1)?.trim() ?? "https";
+  const base = `${proto}://${host}`;
   return NextResponse.json({
     issuer: base,
     authorization_endpoint: `${base}/oauth/authorize`,

--- a/src/app/.well-known/oauth-authorization-server/route.ts
+++ b/src/app/.well-known/oauth-authorization-server/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+import { OAUTH_SUPPORTED_SCOPES, OAUTH_SUPPORTED_GRANT_TYPES, OAUTH_CODE_CHALLENGE_METHODS } from "@/lib/oauth";
+
+/**
+ * GET /.well-known/oauth-authorization-server
+ * OAuth 2.0 Authorization Server Metadata (RFC 8414).
+ * Required by the MCP spec so clients can auto-discover endpoints.
+ */
+export async function GET(req: Request) {
+  const base = new URL(req.url).origin;
+  return NextResponse.json({
+    issuer: base,
+    authorization_endpoint: `${base}/oauth/authorize`,
+    token_endpoint: `${base}/api/oauth/token`,
+    registration_endpoint: `${base}/api/oauth/register`,
+    scopes_supported: [...OAUTH_SUPPORTED_SCOPES],
+    response_types_supported: ["code"],
+    grant_types_supported: [...OAUTH_SUPPORTED_GRANT_TYPES],
+    code_challenge_methods_supported: [...OAUTH_CODE_CHALLENGE_METHODS],
+    token_endpoint_auth_methods_supported: ["none"],
+  });
+}

--- a/src/app/api/[transport]/route.ts
+++ b/src/app/api/[transport]/route.ts
@@ -2,6 +2,7 @@ import { createMcpHandler, withMcpAuth } from "mcp-handler";
 import { timingSafeEqual } from "crypto";
 import { z } from "zod";
 import { buildOverview, listSessions, mcpStrafbuch } from "@/lib/mcpOverview";
+import { verifyAccessToken } from "@/lib/oauth";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -76,17 +77,38 @@ const handler = createMcpHandler(
   { basePath: "/api", maxDuration: 60 },
 );
 
-/** Constant-time bearer-token comparison — avoids a timing side-channel on MCP_TOKEN. */
+/** Constant-time bearer-token comparison — avoids a timing side-channel on MCP_TOKEN.
+ *  Pads both buffers to a fixed length before timingSafeEqual so length differences
+ *  do not leak via early exit. */
 function tokenMatches(token: string, expected: string): boolean {
-  const a = Buffer.from(token);
-  const b = Buffer.from(expected);
-  return a.length === b.length && timingSafeEqual(a, b);
+  const padLen = 128;
+  const a = Buffer.from(token.padEnd(padLen).slice(0, padLen));
+  const b = Buffer.from(expected.padEnd(padLen).slice(0, padLen));
+  return timingSafeEqual(a, b) && token.length === expected.length;
 }
 
+/**
+ * Verifies an incoming MCP bearer token.
+ * Priority:
+ *   1. OAuth access token (issued via /api/oauth/token) — preferred, supports mobile
+ *   2. Static MCP_TOKEN env var — legacy fallback for Claude Desktop config
+ */
 const verifyToken = async (_req: Request, token?: string) => {
+  if (!token) return undefined;
+
+  // 1. OAuth access token
+  const oauthRecord = await verifyAccessToken(token);
+  if (oauthRecord) {
+    return { token, scopes: oauthRecord.scopes.split(" "), clientId: oauthRecord.clientId };
+  }
+
+  // 2. Static bearer token fallback
   const expected = process.env.MCP_TOKEN;
-  if (!expected || !token || !tokenMatches(token, expected)) return undefined;
-  return { token, scopes: ["read"], clientId: "mcp-client" };
+  if (expected && tokenMatches(token, expected)) {
+    return { token, scopes: ["read"], clientId: "mcp-client" };
+  }
+
+  return undefined;
 };
 
 const authHandler = withMcpAuth(handler, verifyToken, { required: true });

--- a/src/app/api/[transport]/route.ts
+++ b/src/app/api/[transport]/route.ts
@@ -1,5 +1,5 @@
 import { createMcpHandler, withMcpAuth } from "mcp-handler";
-import { timingSafeEqual } from "crypto";
+import { timingSafeEqual, createHash } from "crypto";
 import { z } from "zod";
 import { buildOverview, listSessions, mcpStrafbuch } from "@/lib/mcpOverview";
 import { verifyAccessToken } from "@/lib/oauth";
@@ -77,14 +77,13 @@ const handler = createMcpHandler(
   { basePath: "/api", maxDuration: 60 },
 );
 
-/** Constant-time bearer-token comparison — avoids a timing side-channel on MCP_TOKEN.
- *  Pads both buffers to a fixed length before timingSafeEqual so length differences
- *  do not leak via early exit. */
+/** Constant-time bearer-token comparison — avoids timing side-channels on MCP_TOKEN.
+ *  Compares SHA-256 digests so the comparison is always fixed-length regardless of
+ *  the token length (eliminates the truncation risk of a pad-and-slice approach). */
 function tokenMatches(token: string, expected: string): boolean {
-  const padLen = 128;
-  const a = Buffer.from(token.padEnd(padLen).slice(0, padLen));
-  const b = Buffer.from(expected.padEnd(padLen).slice(0, padLen));
-  return timingSafeEqual(a, b) && token.length === expected.length;
+  const a = createHash("sha256").update(token).digest();
+  const b = createHash("sha256").update(expected).digest();
+  return timingSafeEqual(a, b);
 }
 
 /**

--- a/src/app/api/oauth/authorize/route.ts
+++ b/src/app/api/oauth/authorize/route.ts
@@ -1,0 +1,103 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { getClient, clientAllowsRedirect, createAuthorizationCode, scopesValid } from "@/lib/oauth";
+
+/**
+ * GET /api/oauth/authorize
+ * Validates the authorization request and redirects to the consent UI page.
+ * The actual consent form lives at /oauth/authorize (a Next.js page).
+ * This route only validates parameters so the page can trust them.
+ */
+export async function GET(req: NextRequest) {
+  const { searchParams } = req.nextUrl;
+  const clientId = searchParams.get("client_id");
+  const redirectUri = searchParams.get("redirect_uri");
+  const responseType = searchParams.get("response_type");
+  const scope = searchParams.get("scope") ?? "read";
+  const state = searchParams.get("state") ?? "";
+  const codeChallenge = searchParams.get("code_challenge");
+  const codeChallengeMethod = searchParams.get("code_challenge_method");
+
+  function errorRedirect(error: string, description: string) {
+    if (!redirectUri) {
+      return NextResponse.json({ error, error_description: description }, { status: 400 });
+    }
+    const url = new URL(redirectUri);
+    url.searchParams.set("error", error);
+    url.searchParams.set("error_description", description);
+    if (state) url.searchParams.set("state", state);
+    return NextResponse.redirect(url.toString());
+  }
+
+  if (!clientId || !redirectUri) {
+    return NextResponse.json({ error: "invalid_request", error_description: "client_id and redirect_uri are required" }, { status: 400 });
+  }
+  if (responseType !== "code") return errorRedirect("unsupported_response_type", "Only 'code' is supported");
+  if (!codeChallenge) return errorRedirect("invalid_request", "code_challenge is required (PKCE)");
+  if (codeChallengeMethod !== "S256") return errorRedirect("invalid_request", "code_challenge_method must be S256");
+
+  const scopes = scope.split(" ").filter(Boolean);
+  if (!scopesValid(scopes)) return errorRedirect("invalid_scope", "Unsupported scope requested");
+
+  const client = await getClient(clientId);
+  if (!client) return errorRedirect("invalid_client", "Unknown client_id");
+  if (!clientAllowsRedirect(client, redirectUri)) return errorRedirect("invalid_redirect_uri", "redirect_uri not registered");
+
+  // Redirect to consent page (a Next.js page, not an API route)
+  const consentUrl = new URL("/oauth/authorize", req.nextUrl.origin);
+  consentUrl.searchParams.set("client_id", clientId);
+  consentUrl.searchParams.set("redirect_uri", redirectUri);
+  consentUrl.searchParams.set("scope", scopes.join(" "));
+  consentUrl.searchParams.set("state", state);
+  consentUrl.searchParams.set("code_challenge", codeChallenge);
+  consentUrl.searchParams.set("client_name", client.clientName);
+  return NextResponse.redirect(consentUrl.toString());
+}
+
+/**
+ * POST /api/oauth/authorize
+ * Called by the consent form when the user clicks "Erlauben".
+ * Requires an active session — the user must be logged in.
+ */
+export async function POST(req: NextRequest) {
+  const session = await auth();
+  if (!session) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  let body: Record<string, string>;
+  try {
+    body = Object.fromEntries((await req.formData()).entries()) as Record<string, string>;
+  } catch {
+    return NextResponse.json({ error: "invalid_request" }, { status: 400 });
+  }
+
+  const { client_id: clientId, redirect_uri: redirectUri, scope, state, code_challenge: codeChallenge } = body;
+
+  if (!clientId || !redirectUri || !codeChallenge) {
+    return NextResponse.json({ error: "invalid_request" }, { status: 400 });
+  }
+
+  const client = await getClient(clientId);
+  if (!client || !clientAllowsRedirect(client, redirectUri)) {
+    return NextResponse.json({ error: "invalid_client" }, { status: 400 });
+  }
+
+  const scopes = (scope ?? "read").split(" ").filter(Boolean);
+  if (!scopesValid(scopes)) {
+    return NextResponse.json({ error: "invalid_scope" }, { status: 400 });
+  }
+
+  const code = await createAuthorizationCode({
+    clientId,
+    userId: session.user.id,
+    redirectUri,
+    scopes,
+    codeChallenge,
+  });
+
+  const callbackUrl = new URL(redirectUri);
+  callbackUrl.searchParams.set("code", code);
+  if (state) callbackUrl.searchParams.set("state", state);
+  return NextResponse.redirect(callbackUrl.toString());
+}

--- a/src/app/api/oauth/authorize/route.ts
+++ b/src/app/api/oauth/authorize/route.ts
@@ -43,8 +43,11 @@ export async function GET(req: NextRequest) {
   if (!client) return errorRedirect("invalid_client", "Unknown client_id");
   if (!clientAllowsRedirect(client, redirectUri)) return errorRedirect("invalid_redirect_uri", "redirect_uri not registered");
 
-  // Redirect to consent page (a Next.js page, not an API route)
-  const consentUrl = new URL("/oauth/authorize", req.nextUrl.origin);
+  // Redirect to consent page. Behind Traefik req.nextUrl.origin is the internal bind address
+  // (0.0.0.0:3000) — reconstruct the public origin from forwarded headers instead.
+  const host = req.headers.get("x-forwarded-host") ?? req.headers.get("host") ?? req.nextUrl.host;
+  const proto = req.headers.get("x-forwarded-proto")?.split(",").at(-1)?.trim() ?? "https";
+  const consentUrl = new URL("/oauth/authorize", `${proto}://${host}`);
   consentUrl.searchParams.set("client_id", clientId);
   consentUrl.searchParams.set("redirect_uri", redirectUri);
   consentUrl.searchParams.set("scope", scopes.join(" "));

--- a/src/app/api/oauth/register/route.ts
+++ b/src/app/api/oauth/register/route.ts
@@ -1,0 +1,70 @@
+import { NextRequest, NextResponse } from "next/server";
+import { registerClient, OAUTH_SUPPORTED_SCOPES } from "@/lib/oauth";
+import { checkRateLimit } from "@/lib/rate-limit";
+
+/**
+ * POST /api/oauth/register
+ * Dynamic Client Registration (RFC 7591).
+ * Called automatically by Claude Desktop / Claude Mobile on first connection.
+ * No auth required — rate-limited by IP.
+ */
+export async function POST(req: NextRequest) {
+  const ip = req.headers.get("x-forwarded-for")?.split(",").at(-1)?.trim() ?? "unknown";
+  const rl = await checkRateLimit(`oauth-register:${ip}`, 20, 60_000);
+  if (rl.limited) {
+    return NextResponse.json({ error: "too_many_requests" }, { status: 429 });
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "invalid_request", error_description: "Invalid JSON" }, { status: 400 });
+  }
+
+  const clientName = typeof body.client_name === "string" && body.client_name.trim()
+    ? body.client_name.trim()
+    : "Unknown Client";
+
+  // Validate redirect URIs
+  const rawUris = Array.isArray(body.redirect_uris) ? body.redirect_uris : [];
+  const redirectUris: string[] = [];
+  for (const uri of rawUris) {
+    if (typeof uri !== "string") continue;
+    try {
+      const parsed = new URL(uri);
+      const isLocalhost = parsed.hostname === "localhost" || parsed.hostname === "127.0.0.1";
+      const isHttps = parsed.protocol === "https:";
+      // Allow custom app schemes (e.g. claude://) — explicitly block dangerous schemes
+      const isDangerousScheme = ["http:", "javascript:", "data:", "file:", "ftp:", "blob:"].includes(parsed.protocol);
+      const isCustomScheme = !isDangerousScheme && !isHttps;
+      if (isHttps || isLocalhost || isCustomScheme) {
+        redirectUris.push(uri);
+      }
+    } catch {
+      // skip invalid URIs
+    }
+  }
+
+  if (redirectUris.length === 0) {
+    return NextResponse.json(
+      { error: "invalid_redirect_uri", error_description: "At least one valid redirect_uri is required" },
+      { status: 400 }
+    );
+  }
+
+  const client = await registerClient({ clientName, redirectUris });
+
+  return NextResponse.json(
+    {
+      client_id: client.clientId,
+      client_name: client.clientName,
+      redirect_uris: redirectUris,
+      grant_types: ["authorization_code"],
+      response_types: ["code"],
+      scope: OAUTH_SUPPORTED_SCOPES.join(" "),
+      token_endpoint_auth_method: "none",
+    },
+    { status: 201 }
+  );
+}

--- a/src/app/api/oauth/token/route.ts
+++ b/src/app/api/oauth/token/route.ts
@@ -1,0 +1,65 @@
+import { NextRequest, NextResponse } from "next/server";
+import { checkRateLimit } from "@/lib/rate-limit";
+import { getClient, consumeAuthorizationCode, createAccessToken, verifyPkceS256, OAUTH_TOKEN_TTL_MS } from "@/lib/oauth";
+
+/**
+ * POST /api/oauth/token
+ * Authorization Code → Access Token exchange (RFC 6749 §4.1.3).
+ * Validates PKCE S256 code_verifier against the stored code_challenge.
+ */
+export async function POST(req: NextRequest) {
+  const ip = req.headers.get("x-forwarded-for")?.split(",").at(-1)?.trim() ?? "unknown";
+  const rl = await checkRateLimit(`oauth-token:${ip}`, 30, 60_000);
+  if (rl.limited) {
+    return NextResponse.json({ error: "too_many_requests" }, { status: 429 });
+  }
+
+  // Accept both application/x-www-form-urlencoded and application/json
+  let params: Record<string, string>;
+  const ct = req.headers.get("content-type") ?? "";
+  try {
+    if (ct.includes("application/json")) {
+      params = await req.json() as Record<string, string>;
+    } else {
+      params = Object.fromEntries(await req.formData()) as Record<string, string>;
+    }
+  } catch {
+    return NextResponse.json({ error: "invalid_request", error_description: "Unable to parse request body" }, { status: 400 });
+  }
+
+  const { grant_type, code, redirect_uri, client_id: clientId, code_verifier: codeVerifier } = params;
+
+  if (grant_type !== "authorization_code") {
+    return NextResponse.json({ error: "unsupported_grant_type" }, { status: 400 });
+  }
+  if (!code || !redirect_uri || !clientId || !codeVerifier) {
+    return NextResponse.json({ error: "invalid_request", error_description: "Missing required parameters" }, { status: 400 });
+  }
+
+  const client = await getClient(clientId);
+  if (!client) {
+    return NextResponse.json({ error: "invalid_client" }, { status: 401 });
+  }
+
+  const record = await consumeAuthorizationCode(code, clientId, redirect_uri);
+  if (!record) {
+    return NextResponse.json({ error: "invalid_grant", error_description: "Code is invalid, expired, or already used" }, { status: 400 });
+  }
+
+  if (record.codeChallengeMethod !== "S256") {
+    return NextResponse.json({ error: "invalid_grant", error_description: "Unsupported code_challenge_method" }, { status: 400 });
+  }
+  if (!verifyPkceS256(codeVerifier, record.codeChallenge)) {
+    return NextResponse.json({ error: "invalid_grant", error_description: "PKCE verification failed" }, { status: 400 });
+  }
+
+  const scopes = record.scopes.split(" ").filter(Boolean);
+  const accessToken = await createAccessToken(clientId, record.userId, scopes);
+
+  return NextResponse.json({
+    access_token: accessToken,
+    token_type: "Bearer",
+    expires_in: Math.floor(OAUTH_TOKEN_TTL_MS / 1000),
+    scope: record.scopes,
+  });
+}

--- a/src/app/api/oauth/token/route.ts
+++ b/src/app/api/oauth/token/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { checkRateLimit } from "@/lib/rate-limit";
-import { getClient, consumeAuthorizationCode, createAccessToken, verifyPkceS256, OAUTH_TOKEN_TTL_MS } from "@/lib/oauth";
+import { getClient, consumeAuthorizationCode, createAccessToken, verifyPkceS256, OAUTH_TOKEN_TTL_MS, pruneExpiredOAuthRecords } from "@/lib/oauth";
 
 /**
  * POST /api/oauth/token
@@ -55,6 +55,9 @@ export async function POST(req: NextRequest) {
 
   const scopes = record.scopes.split(" ").filter(Boolean);
   const accessToken = await createAccessToken(clientId, record.userId, scopes);
+
+  // Lazy cleanup — prune expired codes and tokens on every successful exchange (fire-and-forget).
+  pruneExpiredOAuthRecords().catch(() => {});
 
   return NextResponse.json({
     access_token: accessToken,

--- a/src/app/oauth/authorize/page.tsx
+++ b/src/app/oauth/authorize/page.tsx
@@ -1,0 +1,119 @@
+import { redirect } from "next/navigation";
+import { auth } from "@/lib/auth";
+import { ShieldCheck } from "lucide-react";
+import Card from "@/app/components/Card";
+import Button from "@/app/components/Button";
+import { getClient, clientAllowsRedirect } from "@/lib/oauth";
+
+interface Props {
+  searchParams: Promise<{
+    client_id?: string;
+    redirect_uri?: string;
+    scope?: string;
+    state?: string;
+    code_challenge?: string;
+    client_name?: string;
+  }>;
+}
+
+export default async function OAuthAuthorizePage({ searchParams }: Props) {
+  const session = await auth();
+  const params = await searchParams;
+
+  const { client_id, redirect_uri, scope, state, code_challenge, client_name } = params;
+
+  // Missing params — show generic error
+  if (!client_id || !redirect_uri || !code_challenge) {
+    return <OAuthError message="Ungültige Anfrage: fehlende Parameter." />;
+  }
+
+  // Validate client and redirect_uri server-side — never trust URL params alone.
+  // This prevents open redirects and phishing via crafted client_name params.
+  const client = await getClient(client_id);
+  if (!client || !clientAllowsRedirect(client, redirect_uri)) {
+    return <OAuthError message="Ungültige Anfrage: unbekannter Client oder redirect_uri nicht registriert." />;
+  }
+
+  // Not logged in → redirect to login, then back here
+  if (!session) {
+    const returnUrl = `/oauth/authorize?${new URLSearchParams(params as Record<string, string>).toString()}`;
+    redirect(`/login?callbackUrl=${encodeURIComponent(returnUrl)}`);
+  }
+
+  const scopeList = (scope ?? "read").split(" ").filter(Boolean);
+  // Use the DB-stored client name — never the URL param (attacker-controlled)
+  const appName = client.clientName;
+
+  return (
+    <div className="min-h-screen flex items-center justify-center p-4">
+      <div className="w-full max-w-sm">
+        <Card>
+          <div className="flex flex-col items-center gap-5 p-6">
+            <div className="w-14 h-14 rounded-2xl bg-lock flex items-center justify-center">
+              <ShieldCheck size={28} className="text-white" />
+            </div>
+
+            <div className="text-center">
+              <h1 className="text-lg font-semibold mb-1">Zugriff erlauben?</h1>
+              <p className="text-sm text-foreground-muted">
+                <strong>{appName}</strong> möchte auf deinen ChastityTracker zugreifen.
+              </p>
+            </div>
+
+            <div className="w-full rounded-xl border border-border bg-surface-subtle p-4">
+              <p className="text-xs font-medium text-foreground-muted uppercase tracking-wide mb-2">
+                Berechtigungen
+              </p>
+              <ul className="space-y-1">
+                {scopeList.includes("read") && (
+                  <li className="text-sm flex items-start gap-2">
+                    <span className="text-lock mt-0.5">✓</span>
+                    <span>Lesezugriff auf Tracker-Daten (Einschlüsse, Statistiken, Strafbuch)</span>
+                  </li>
+                )}
+              </ul>
+              <p className="text-xs text-foreground-faint mt-3">
+                Kein Schreibzugriff — keine Änderungen an deinen Daten möglich.
+              </p>
+            </div>
+
+            <p className="text-xs text-foreground-faint text-center">
+              Eingeloggt als <strong>{session?.user?.name}</strong>
+            </p>
+
+            <form action="/api/oauth/authorize" method="POST" className="w-full flex flex-col gap-3">
+              <input type="hidden" name="client_id" value={client_id} />
+              <input type="hidden" name="redirect_uri" value={redirect_uri} />
+              <input type="hidden" name="scope" value={scope ?? "read"} />
+              <input type="hidden" name="state" value={state ?? ""} />
+              <input type="hidden" name="code_challenge" value={code_challenge} />
+
+              <Button type="submit" variant="semantic" semantic="lock" fullWidth>
+                Erlauben
+              </Button>
+
+              <a
+                href={(() => { const u = new URL(redirect_uri); u.searchParams.set("error", "access_denied"); if (state) u.searchParams.set("state", state); return u.toString(); })()}
+                className="text-sm text-center text-foreground-muted hover:text-foreground transition"
+              >
+                Ablehnen
+              </a>
+            </form>
+          </div>
+        </Card>
+      </div>
+    </div>
+  );
+}
+
+function OAuthError({ message }: { message: string }) {
+  return (
+    <div className="min-h-screen flex items-center justify-center p-4">
+      <Card>
+        <div className="p-6 text-center">
+          <p className="text-sm text-warn">{message}</p>
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/src/data/changelog.json
+++ b/src/data/changelog.json
@@ -1,5 +1,12 @@
 [
   {
+    "version": "4.18.6",
+    "date": "2026-05-27",
+    "changes": [
+      { "type": "feat", "text": "OAuth 2.0 Authorization Server für den MCP-Server: Claude Mobile und Claude Desktop können sich jetzt per OAuth (Authorization Code + PKCE) authentifizieren statt mit einem statischen Bearer-Token. Neuer Consent-Screen unter /oauth/authorize, Discovery-Endpoint unter /.well-known/oauth-authorization-server, Dynamic Client Registration." }
+    ]
+  },
+  {
     "version": "4.18.5",
     "date": "2026-05-26",
     "changes": [

--- a/src/data/changelog.json
+++ b/src/data/changelog.json
@@ -1,5 +1,12 @@
 [
   {
+    "version": "4.18.9",
+    "date": "2026-05-28",
+    "changes": [
+      { "type": "chore", "text": "MCP-API: schemaVersion: 1 zu allen drei Tool-Responses hinzugefügt (get_overview, get_strafbuch, list_sessions), damit Breaking Changes künftig nachvollziehbar sind. list_sessions gibt jetzt { schemaVersion, sessions: [...] } zurück statt ein reines Array." }
+    ]
+  },
+  {
     "version": "4.18.8",
     "date": "2026-05-28",
     "changes": [

--- a/src/data/changelog.json
+++ b/src/data/changelog.json
@@ -1,5 +1,12 @@
 [
   {
+    "version": "4.18.8",
+    "date": "2026-05-28",
+    "changes": [
+      { "type": "chore", "text": "MCP-API: Feldnamen bereinigt — deutsche Namen eingedeutscht (kommentar→comment, nachricht→message, sperrzeitEndedAt→lockPeriodEndedAt, reinigungLimitViolations→cleaningLimitViolations, trainingGoalKg.minProTagH/Woche/Monat/notiz→minPerDayH/WeekH/MonthH/note), semantische Verwechslung behoben (recordedCount→punishedCount, totalOffenses→detectedOffenseCount), punished-Flag auf cleaningLimitViolations ergänzt." }
+    ]
+  },
+  {
     "version": "4.18.7",
     "date": "2026-05-28",
     "changes": [

--- a/src/data/changelog.json
+++ b/src/data/changelog.json
@@ -1,5 +1,15 @@
 [
   {
+    "version": "4.18.7",
+    "date": "2026-05-28",
+    "changes": [
+      { "type": "security", "text": "OAuth: tokenMatches verwendet jetzt SHA-256-Digest-Vergleich statt Pad-und-Truncate — verhindert Fälschung von MCP_TOKEN-Tokens die länger als 128 Zeichen sind." },
+      { "type": "fix", "text": "OAuth Discovery-Endpoint und Authorize-Redirect lesen jetzt x-forwarded-host/x-forwarded-proto (last entry per Projekt-Sicherheitsregel) statt der internen Bind-Adresse — behebt falsche Issuer-URL (0.0.0.0:3000) hinter Traefik." },
+      { "type": "fix", "text": "SSE- und Message-Transportpfade des MCP-Servers (/api/sse, /api/message) in den Proxy-Whitelist aufgenommen — OAuth-Clients mit SSE-Transport erhielten zuvor 401 vom Session-Gate statt vom MCP-Auth-Layer." },
+      { "type": "fix", "text": "Abgelaufene OAuth-Codes und -Tokens werden jetzt beim Token-Exchange bereinigt (fire-and-forget pruneExpiredOAuthRecords)." }
+    ]
+  },
+  {
     "version": "4.18.6",
     "date": "2026-05-27",
     "changes": [

--- a/src/lib/mcpOverview.ts
+++ b/src/lib/mcpOverview.ts
@@ -22,20 +22,22 @@ export interface TrackerOverview {
   };
   wearingHoursKg: { today: number; week: number; month: number };
   trainingGoalKg: {
-    minProTagH: number | null; todayPct: number | null;
-    minProWocheH: number | null; weekPct: number | null;
-    minProMonatH: number | null; monthPct: number | null;
-    notiz: string | null;
+    minPerDayH: number | null; todayPct: number | null;
+    minPerWeekH: number | null; weekPct: number | null;
+    minPerMonthH: number | null; monthPct: number | null;
+    note: string | null;
   } | null;
-  openKontrolle: { code: string; deadline: string; overdue: boolean; remainingMinutes: number; kommentar: string | null } | null;
-  activeSperrzeit: { endetAt: string | null; indefinite: boolean; remainingMinutes: number | null; nachricht: string | null } | null;
-  openVerschlussAnforderung: { endetAt: string | null; overdue: boolean; remainingMinutes: number | null; nachricht: string | null; dauerH: number | null } | null;
+  openKontrolle: { code: string; deadline: string; overdue: boolean; remainingMinutes: number; comment: string | null } | null;
+  activeSperrzeit: { endetAt: string | null; indefinite: boolean; remainingMinutes: number | null; message: string | null } | null;
+  openVerschlussAnforderung: { endetAt: string | null; overdue: boolean; remainingMinutes: number | null; message: string | null; dauerH: number | null } | null;
   sessionSummary: {
     totalSessions: number; totalHours: number; avgHours: number;
     longestHours: number; shortestHours: number;
     lastOrgasmAt: string | null; orgasmFreeHours: number | null;
   } | null;
-  penalties: { recordedCount: number };
+  /** punishedCount: admin-confirmed punishments (StrafeRecord rows).
+   *  Distinct from detectedOffenseCount in get_strafbuch which counts system-detected offenses. */
+  penalties: { punishedCount: number };
   activeWearSessions: { category: string; deviceName: string; since: string; durationHours: number }[];
 }
 
@@ -64,7 +66,7 @@ export async function buildOverview(username: string): Promise<TrackerOverview> 
   const fmt = (d: Date) => formatDateTime(d);
   const minutesUntil = (d: Date) => Math.round((d.getTime() - now.getTime()) / 60_000);
 
-  const [entries, openKontrolle, activeVorgabe, activeSperrzeit, openAnf, activeWear, penaltyCount] = await Promise.all([
+  const [entries, openKontrolle, activeVorgabe, activeSperrzeit, openAnf, activeWear, punishedCount] = await Promise.all([
     prisma.entry.findMany({
       where: { userId },
       orderBy: { startTime: "desc" },
@@ -113,32 +115,32 @@ export async function buildOverview(username: string): Promise<TrackerOverview> 
     },
     wearingHoursKg: { today: round1(tagH), week: round1(wocheH), month: round1(monatH) },
     trainingGoalKg: activeVorgabe ? {
-      minProTagH: activeVorgabe.minProTagH,
+      minPerDayH: activeVorgabe.minProTagH,
       todayPct: pct(tagH, activeVorgabe.minProTagH),
-      minProWocheH: activeVorgabe.minProWocheH,
+      minPerWeekH: activeVorgabe.minProWocheH,
       weekPct: pct(wocheH, activeVorgabe.minProWocheH),
-      minProMonatH: activeVorgabe.minProMonatH,
+      minPerMonthH: activeVorgabe.minProMonatH,
       monthPct: pct(monatH, activeVorgabe.minProMonatH),
-      notiz: activeVorgabe.notiz,
+      note: activeVorgabe.notiz,
     } : null,
     openKontrolle: openKontrolle ? {
       code: openKontrolle.code,
       deadline: fmt(openKontrolle.deadline),
       overdue: openKontrolle.deadline < now,
       remainingMinutes: minutesUntil(openKontrolle.deadline),
-      kommentar: openKontrolle.kommentar,
+      comment: openKontrolle.kommentar,
     } : null,
     activeSperrzeit: activeSperrzeit ? {
       endetAt: activeSperrzeit.endetAt ? fmt(activeSperrzeit.endetAt) : null,
       indefinite: activeSperrzeit.endetAt === null,
       remainingMinutes: activeSperrzeit.endetAt ? minutesUntil(activeSperrzeit.endetAt) : null,
-      nachricht: activeSperrzeit.nachricht,
+      message: activeSperrzeit.nachricht,
     } : null,
     openVerschlussAnforderung: openAnf ? {
       endetAt: openAnf.endetAt ? fmt(openAnf.endetAt) : null,
       overdue: openAnf.endetAt ? openAnf.endetAt < now : false,
       remainingMinutes: openAnf.endetAt ? minutesUntil(openAnf.endetAt) : null,
-      nachricht: openAnf.nachricht,
+      message: openAnf.nachricht,
       dauerH: openAnf.dauerH,
     } : null,
     sessionSummary: summary.count > 0 ? {
@@ -150,7 +152,7 @@ export async function buildOverview(username: string): Promise<TrackerOverview> 
       lastOrgasmAt: lastOrgasmus ? fmt(lastOrgasmus.startTime) : null,
       orgasmFreeHours: lastOrgasmus ? msToHours(now.getTime() - lastOrgasmus.startTime.getTime()) : null,
     } : null,
-    penalties: { recordedCount: penaltyCount },
+    penalties: { punishedCount },
     activeWearSessions: activeWear.map((s) => ({
       category: s.categoryName,
       deviceName: s.deviceName,
@@ -255,7 +257,7 @@ export interface StrafbuchControlRow {
   fulfilledAt: string | null;
   entryTime: string | null;
   backdated: boolean;
-  kommentar: string | null;
+  comment: string | null;
   entryNote: string | null;
   punished: boolean;
 }
@@ -265,15 +267,17 @@ export interface StrafbuchOverview {
   user: string;
   generatedAt: string;
   timezone: string;
-  totalOffenses: number;
+  /** Total number of system-detected offenses across all categories.
+   *  Distinct from penalties.punishedCount in get_overview which counts admin-confirmed punishments. */
+  detectedOffenseCount: number;
   unauthorizedOpenings: {
     time: string; note: string | null;
-    sperrzeitEndedAt: string | null; sperrzeitIndefinite: boolean;
+    lockPeriodEndedAt: string | null; lockPeriodIndefinite: boolean;
     punished: boolean;
   }[];
   lateControls: StrafbuchControlRow[];
   rejectedControls: StrafbuchControlRow[];
-  reinigungLimitViolations: { time: string | null; note: string | null }[];
+  cleaningLimitViolations: { time: string | null; note: string | null; punished: boolean }[];
 }
 
 /** Builds the Strafbuch snapshot for the user. Throws if the user does not exist. */
@@ -290,7 +294,7 @@ export async function mcpStrafbuch(username: string): Promise<StrafbuchOverview>
     fulfilledAt: k.fulfilledAt ? fmt(k.fulfilledAt) : null,
     entryTime: k.entryStartTime ? fmt(k.entryStartTime) : null,
     backdated: k.backdated,
-    kommentar: k.kommentar,
+    comment: k.kommentar,
     entryNote: k.entryNote,
     punished: punished.has(k.id),
   });
@@ -299,21 +303,22 @@ export async function mcpStrafbuch(username: string): Promise<StrafbuchOverview>
     user: username,
     generatedAt: fmt(now),
     timezone: APP_TZ,
-    totalOffenses:
+    detectedOffenseCount:
       sb.unauthorizedOpenings.length + sb.lateControls.length +
       sb.rejectedControls.length + sb.reinigungLimitViolations.length,
     unauthorizedOpenings: sb.unauthorizedOpenings.map((o) => ({
       time: fmt(o.startTime),
       note: o.note,
-      sperrzeitEndedAt: o.sperrzeitEndetAt ? fmt(o.sperrzeitEndetAt) : null,
-      sperrzeitIndefinite: o.sperrzeitIndefinite,
+      lockPeriodEndedAt: o.sperrzeitEndetAt ? fmt(o.sperrzeitEndetAt) : null,
+      lockPeriodIndefinite: o.sperrzeitIndefinite,
       punished: punished.has(o.id),
     })),
     lateControls: sb.lateControls.map(toControlRow),
     rejectedControls: sb.rejectedControls.map(toControlRow),
-    reinigungLimitViolations: sb.reinigungLimitViolations.map((v) => ({
+    cleaningLimitViolations: sb.reinigungLimitViolations.map((v) => ({
       time: v.startTime ? fmt(v.startTime) : null,
       note: v.note,
+      punished: punished.has(v.entryId),
     })),
   };
 }

--- a/src/lib/mcpOverview.ts
+++ b/src/lib/mcpOverview.ts
@@ -11,6 +11,7 @@ import { buildStrafbuch, type StrafbuchControlOffense } from "@/lib/strafbuch";
  *  Timestamps are human strings in the instance timezone (see `timezone`) — NOT UTC,
  *  so a consuming LLM reads wall-clock time directly. Durations are hours (1 decimal). */
 export interface TrackerOverview {
+  schemaVersion: 1;
   user: string;
   generatedAt: string;
   timezone: string;
@@ -104,6 +105,7 @@ export async function buildOverview(username: string): Promise<TrackerOverview> 
   const { tagH, wocheH, monatH } = calculateWearingHoursByRange(entries, now, reinigung);
 
   return {
+    schemaVersion: 1 as const,
     user: username,
     generatedAt: fmt(now),
     timezone: APP_TZ,
@@ -171,6 +173,11 @@ export interface SessionRow {
   durationHours: number;
 }
 
+export interface SessionList {
+  schemaVersion: 1;
+  sessions: SessionRow[];
+}
+
 export interface ListSessionsOptions {
   /** "KG" or a category name (case-insensitive). Omit for all categories. */
   category?: string;
@@ -210,7 +217,7 @@ function completedWearSessions(
 }
 
 /** Lists completed sessions (KG + non-KG wear), newest first. Throws if the user does not exist. */
-export async function listSessions(username: string, opts: ListSessionsOptions = {}): Promise<SessionRow[]> {
+export async function listSessions(username: string, opts: ListSessionsOptions = {}): Promise<SessionList> {
   const { userId, reinigung } = await loadUserContext(username);
 
   const [entries, nonKgCategories] = await Promise.all([
@@ -236,7 +243,7 @@ export async function listSessions(username: string, opts: ListSessionsOptions =
   const filter = opts.category?.trim().toLowerCase();
   const limit = Math.min(Math.max(1, opts.limit ?? 20), 100);
 
-  return [...kg, ...wear]
+  const sessions = [...kg, ...wear]
     .filter((s) => s.durationMs > 0)
     .filter((s) => !filter || s.category.toLowerCase() === filter)
     .sort((a, b) => b.start.getTime() - a.start.getTime())
@@ -248,6 +255,7 @@ export async function listSessions(username: string, opts: ListSessionsOptions =
       end: formatDateTime(s.end),
       durationHours: msToHours(s.durationMs),
     }));
+  return { schemaVersion: 1 as const, sessions };
 }
 
 /** A Kontroll-based offense formatted for the MCP `get_strafbuch` tool. */
@@ -264,6 +272,7 @@ export interface StrafbuchControlRow {
 
 /** Strafbuch snapshot for the MCP `get_strafbuch` tool. Timestamps in the instance timezone. */
 export interface StrafbuchOverview {
+  schemaVersion: 1;
   user: string;
   generatedAt: string;
   timezone: string;
@@ -300,6 +309,7 @@ export async function mcpStrafbuch(username: string): Promise<StrafbuchOverview>
   });
 
   return {
+    schemaVersion: 1 as const,
     user: username,
     generatedAt: fmt(now),
     timezone: APP_TZ,

--- a/src/lib/oauth.ts
+++ b/src/lib/oauth.ts
@@ -1,0 +1,149 @@
+import crypto from "crypto";
+import { prisma } from "@/lib/prisma";
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+export const OAUTH_CODE_TTL_MS = 10 * 60 * 1000; // 10 minutes
+export const OAUTH_TOKEN_TTL_MS = 365 * 24 * 60 * 60 * 1000; // 1 year
+export const OAUTH_SUPPORTED_SCOPES = ["read"] as const;
+export const OAUTH_SUPPORTED_GRANT_TYPES = ["authorization_code"] as const;
+export const OAUTH_CODE_CHALLENGE_METHODS = ["S256"] as const;
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Generates a cryptographically random URL-safe token string. */
+export function generateToken(byteLength = 32): string {
+  return crypto.randomBytes(byteLength).toString("base64url");
+}
+
+/** SHA-256 hex digest — used to store tokens without plaintext. */
+export function hashToken(token: string): string {
+  return crypto.createHash("sha256").update(token).digest("hex");
+}
+
+/** Verifies a PKCE S256 code verifier against a stored challenge.
+ *  challenge = BASE64URL(SHA256(verifier)) */
+export function verifyPkceS256(verifier: string, challenge: string): boolean {
+  const expected = crypto
+    .createHash("sha256")
+    .update(verifier)
+    .digest("base64url");
+  const a = Buffer.from(expected);
+  const b = Buffer.from(challenge);
+  return a.length === b.length && crypto.timingSafeEqual(a, b);
+}
+
+/** Returns true if all requested scopes are within the supported set. */
+export function scopesValid(scopes: string[]): boolean {
+  return scopes.every((s) =>
+    (OAUTH_SUPPORTED_SCOPES as readonly string[]).includes(s)
+  );
+}
+
+// ── Client registration ──────────────────────────────────────────────────────
+
+export interface RegisterClientInput {
+  clientName: string;
+  redirectUris: string[];
+}
+
+export async function registerClient(input: RegisterClientInput) {
+  const clientId = generateToken(16);
+  const client = await prisma.oAuthClient.create({
+    data: {
+      clientId,
+      clientName: input.clientName,
+      redirectUris: JSON.stringify(input.redirectUris),
+    },
+  });
+  return client;
+}
+
+export async function getClient(clientId: string) {
+  return prisma.oAuthClient.findUnique({ where: { clientId } });
+}
+
+export function clientAllowsRedirect(client: { redirectUris: string }, uri: string): boolean {
+  const allowed: string[] = JSON.parse(client.redirectUris);
+  return allowed.includes(uri);
+}
+
+// ── Authorization codes ──────────────────────────────────────────────────────
+
+export interface CreateCodeInput {
+  clientId: string;
+  userId: string;
+  redirectUri: string;
+  scopes: string[];
+  codeChallenge: string;
+}
+
+export async function createAuthorizationCode(input: CreateCodeInput): Promise<string> {
+  const code = generateToken(32);
+  await prisma.oAuthCode.create({
+    data: {
+      code,
+      clientId: input.clientId,
+      userId: input.userId,
+      redirectUri: input.redirectUri,
+      scopes: input.scopes.join(" "),
+      codeChallenge: input.codeChallenge,
+      codeChallengeMethod: "S256",
+      expiresAt: new Date(Date.now() + OAUTH_CODE_TTL_MS),
+    },
+  });
+  return code;
+}
+
+/** Retrieves and atomically marks the code as used (single-use).
+ *  Uses a conditional updateMany so concurrent requests cannot both succeed.
+ *  Returns null if the code is invalid, expired, already used, or the client/redirect don't match. */
+export async function consumeAuthorizationCode(code: string, clientId: string, redirectUri: string) {
+  const now = new Date();
+  // Single atomic write: only succeeds if the code exists, matches, is unused, and not expired.
+  const result = await prisma.oAuthCode.updateMany({
+    where: { code, clientId, redirectUri, usedAt: null, expiresAt: { gt: now } },
+    data: { usedAt: now },
+  });
+  if (result.count === 0) return null;
+  return prisma.oAuthCode.findUnique({ where: { code } });
+}
+
+// ── Access tokens ────────────────────────────────────────────────────────────
+
+export async function createAccessToken(clientId: string, userId: string, scopes: string[]): Promise<string> {
+  const raw = generateToken(32);
+  const tokenHash = hashToken(raw);
+  await prisma.oAuthToken.create({
+    data: {
+      tokenHash,
+      clientId,
+      userId,
+      scopes: scopes.join(" "),
+      expiresAt: new Date(Date.now() + OAUTH_TOKEN_TTL_MS),
+    },
+  });
+  return raw;
+}
+
+/** Looks up a token by its hash. Returns the record if valid (not expired), else null. */
+export async function verifyAccessToken(raw: string) {
+  const tokenHash = hashToken(raw);
+  const record = await prisma.oAuthToken.findUnique({ where: { tokenHash } });
+  if (!record) return null;
+  if (record.expiresAt < new Date()) return null;
+  return record;
+}
+
+// ── Cleanup ──────────────────────────────────────────────────────────────────
+
+/** Deletes expired codes and tokens. Call from a background job or on-demand.
+ *  Note: used-but-unexpired codes are intentionally retained until their TTL elapses
+ *  to prevent replay attacks (the usedAt check happens before expiry check). */
+export async function pruneExpiredOAuthRecords(): Promise<void> {
+  const now = new Date();
+  await Promise.all([
+    prisma.oAuthCode.deleteMany({ where: { expiresAt: { lt: now } } }),
+    prisma.oAuthToken.deleteMany({ where: { expiresAt: { lt: now } } }),
+  ]);
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -54,7 +54,9 @@ export default auth((req) => {
 
   // /api/mcp authenticates itself via bearer token (withMcpAuth) — exempt from the NextAuth session gate.
   // OAuth endpoints are public: clients call them directly; the consent page redirects to /login itself.
-  const isAuthRoute = pathname.startsWith("/api/auth") || pathname === "/login" || pathname === "/api/version" || pathname === "/api/portal-login" || pathname === "/api/mcp"
+  // /api/mcp, /api/sse, /api/message: mcp-handler transport paths — all authenticated via withMcpAuth (bearer token), not session.
+  const isAuthRoute = pathname.startsWith("/api/auth") || pathname === "/login" || pathname === "/api/version" || pathname === "/api/portal-login"
+    || pathname === "/api/mcp" || pathname === "/api/sse" || pathname === "/api/message"
     || pathname.startsWith("/api/oauth/") || pathname.startsWith("/.well-known/") || pathname.startsWith("/oauth/");
   const isAdminRoute = pathname.startsWith("/admin") || pathname.startsWith("/api/admin");
   const isProtected =

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -53,7 +53,9 @@ export default auth((req) => {
   const role = user?.role;
 
   // /api/mcp authenticates itself via bearer token (withMcpAuth) — exempt from the NextAuth session gate.
-  const isAuthRoute = pathname.startsWith("/api/auth") || pathname === "/login" || pathname === "/api/version" || pathname === "/api/portal-login" || pathname === "/api/mcp";
+  // OAuth endpoints are public: clients call them directly; the consent page redirects to /login itself.
+  const isAuthRoute = pathname.startsWith("/api/auth") || pathname === "/login" || pathname === "/api/version" || pathname === "/api/portal-login" || pathname === "/api/mcp"
+    || pathname.startsWith("/api/oauth/") || pathname.startsWith("/.well-known/") || pathname.startsWith("/oauth/");
   const isAdminRoute = pathname.startsWith("/admin") || pathname.startsWith("/api/admin");
   const isProtected =
     pathname.startsWith("/dashboard") ||


### PR DESCRIPTION
## Summary

- Implements OAuth 2.0 Authorization Code + PKCE flow for the MCP server
- Claude Mobile / Claude Desktop can now authenticate without a hardcoded `MCP_TOKEN`
- Static `MCP_TOKEN` env var remains as a backwards-compatible fallback

## New endpoints

| Endpoint | Purpose |
|---|---|
| `GET /.well-known/oauth-authorization-server` | RFC 8414 discovery |
| `POST /api/oauth/register` | Dynamic Client Registration (RFC 7591) |
| `GET /api/oauth/authorize` | Validates params, redirects to consent UI |
| `POST /api/oauth/authorize` | Consent form submission → issues auth code |
| `POST /api/oauth/token` | Code → access token exchange (PKCE S256) |
| `GET /oauth/authorize` | Consent UI page (server component) |

## Security measures

- Atomic single-use code redemption via `updateMany` (no TOCTOU race)
- Tokens stored as SHA-256 hashes only — never plaintext
- PKCE S256 enforced at both authorization and token endpoints
- Server-side `redirect_uri` validation on consent page (prevents open redirect)
- Dangerous URI schemes (`javascript:`, `data:`, `file:`) blocked at registration
- Constant-time token comparison with fixed-length padding

## Test plan

- [ ] Add MCP server to Claude Mobile — confirm OAuth flow opens browser
- [ ] Log in, click "Erlauben" on consent screen
- [ ] Confirm Claude Mobile can call `get_overview` / `list_sessions` / `get_strafbuch`
- [ ] Confirm existing `MCP_TOKEN` static config still works (backwards compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)