### PR TITLE
ui(dashboard): Anforderungs-Banner ganz nach oben (v4.55.5)

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -263,7 +263,6 @@
     "orgasmWindowFromUntil": "Zeitfenster: {from} – {until}",
     "orgasmRequiredArt": "Gewünscht: {art}",
     "locked": "Verschlossen",
-    "openingForbiddenUntil": "Öffnen nicht erlaubt bis {date}",
     "inspectionRequired": "Kontrolle erforderlich",
     "entries": "Sessions",
     "totalDuration": "Gesamtdauer",

--- a/messages/en.json
+++ b/messages/en.json
@@ -263,7 +263,6 @@
     "orgasmWindowFromUntil": "Window: {from} – {until}",
     "orgasmRequiredArt": "Requested: {art}",
     "locked": "Locked",
-    "openingForbiddenUntil": "Opening not allowed until {date}",
     "inspectionRequired": "Inspection required",
     "entries": "Sessions",
     "totalDuration": "Total duration",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kg-app",
-  "version": "4.55.3",
+  "version": "4.55.5",
   "private": true,
   "license": "SEE LICENSE IN LICENSE.md",
   "scripts": {

--- a/src/app/components/BoxStatusCard.tsx
+++ b/src/app/components/BoxStatusCard.tsx
@@ -2,7 +2,7 @@
 
 import { Lock, LockOpen, AlertTriangle } from "lucide-react";
 import { useLocale, useTranslations } from "next-intl";
-import { formatDateTimeDual, toDateLocale, APP_TZ } from "@/lib/utils";
+import { formatDateTimeDual, toDateLocale, joinParts, APP_TZ } from "@/lib/utils";
 import { boxIsPhysicallyLocked, boxIstLabel, boxPendingTransition, boxSollLabel, boxSollLocked, boxFreshnessLabel, boxBatteryLabel, boxReinigungLabel, boxReinigungQuotaLabel, boxFailsafeWarnings, boxFailsafeLabel, type BoxReinigungView } from "@/lib/boxStatus";
 import { useBoxStatus } from "@/app/hooks/useBoxStatus";
 import DashboardBlock from "@/app/components/DashboardBlock";
@@ -112,7 +112,7 @@ export default function BoxStatusCard({ tz = APP_TZ, reinigung, userId, viewerTz
                       Alterung automatisch mit („zuletzt online vor 19 Std · Akku niedrig"); zwei
                       getrennte Zeilen liessen den Akkustand aktuell wirken. */}
                   <p className="text-xs text-foreground-faint">
-                    {[boxFreshnessLabel(b.lastSyncAt, now, t), batteryLabel].filter(Boolean).join(" · ")}
+                    {joinParts(boxFreshnessLabel(b.lastSyncAt, now, t), batteryLabel)}
                   </p>
                 </div>
               </div>

--- a/src/app/dashboard/DashboardAlerts.tsx
+++ b/src/app/dashboard/DashboardAlerts.tsx
@@ -1,0 +1,88 @@
+import { getTranslations, getLocale } from "next-intl/server";
+import KontrolleBanner from "@/app/components/KontrolleBanner";
+import LockRequestBanner from "@/app/components/LockRequestBanner";
+import DashboardBlock from "@/app/components/DashboardBlock";
+import { inspectionHelpUrl } from "@/lib/constants";
+
+/** Die Anforderungen mit Frist — Kontrolle, Einschliessen, Orgasmus.
+ *
+ *  Bewusst ein EIGENER Block ganz oben statt Teil des `DashboardClient`: dort sassen sie unterhalb
+ *  von Box-Karte, Session-Karte, Trage-Sessions, Trainingsvorgaben und „Nicht getragen" und lagen
+ *  damit je nach Ausstattung unter dem Fold — eine Frist, die man wegscrollen muss, verfehlt ihren
+ *  Zweck (Rückmeldung 28.07.2026). Sie stehen jetzt vor allem anderen, auch vor der Box-Karte.
+ *
+ *  Rendert nichts, wenn keine Anforderung offen ist: als leerer Block wäre er kein Flex-Item mehr
+ *  und überspringt seinen Abstand automatisch (siehe `DashboardBlock`). */
+export interface DashboardAlertsProps {
+  offeneKontrolle: {
+    deadline: string;
+    code: string;
+    kommentar: string | null;
+    overdue: boolean;
+    href: string;
+  } | null;
+
+  offeneVerschlussAnf: {
+    nachricht: string | null;
+    endetAtLabel: string | null;
+  } | null;
+
+  offeneOrgasmusAnf: {
+    label: string;
+    nachricht: string | null;
+    windowLabel: string;
+  } | null;
+
+  /** Governing timezone of the data owner (sub). Defaults to APP_TZ (Europe/Zurich). */
+  tz?: string;
+}
+
+export default async function DashboardAlerts({
+  offeneKontrolle,
+  offeneVerschlussAnf,
+  offeneOrgasmusAnf,
+  tz,
+}: DashboardAlertsProps) {
+  if (!offeneKontrolle && !offeneVerschlussAnf && !offeneOrgasmusAnf) return null;
+
+  const t = await getTranslations("dashboard");
+  const locale = await getLocale();
+
+  return (
+    <DashboardBlock className="flex flex-col gap-4">
+      {offeneKontrolle && (
+        <KontrolleBanner
+          deadline={new Date(offeneKontrolle.deadline)}
+          code={offeneKontrolle.code}
+          kommentar={offeneKontrolle.kommentar}
+          overdue={offeneKontrolle.overdue}
+          variant="large"
+          href={offeneKontrolle.href}
+          openLabel={t("inspectionRequired")}
+          helpHref={inspectionHelpUrl(locale)}
+          tz={tz}
+        />
+      )}
+
+      {offeneVerschlussAnf && (
+        <LockRequestBanner
+          variant="large"
+          colorScheme="request"
+          label={t("lockRequested")}
+          nachricht={offeneVerschlussAnf.nachricht}
+          endetAtLabel={offeneVerschlussAnf.endetAtLabel}
+        />
+      )}
+
+      {offeneOrgasmusAnf && (
+        <LockRequestBanner
+          variant="large"
+          colorScheme="orgasm"
+          label={offeneOrgasmusAnf.label}
+          nachricht={offeneOrgasmusAnf.nachricht}
+          endetAtLabel={offeneOrgasmusAnf.windowLabel}
+        />
+      )}
+    </DashboardBlock>
+  );
+}

--- a/src/app/dashboard/DashboardClient.tsx
+++ b/src/app/dashboard/DashboardClient.tsx
@@ -5,15 +5,12 @@ import { useEffect } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { Lock, LockOpen } from "lucide-react";
-import { useTranslations, useLocale } from "next-intl";
+import { useTranslations } from "next-intl";
 import TimerDisplay from "@/app/components/TimerDisplay";
 import Button from "@/app/components/Button";
 import EmptyState from "@/app/components/EmptyState";
-import KontrolleBanner from "@/app/components/KontrolleBanner";
-import LockRequestBanner from "@/app/components/LockRequestBanner";
 import DashboardBlock from "@/app/components/DashboardBlock";
 import { formatHoursHM } from "@/lib/utils";
-import { inspectionHelpUrl } from "@/lib/constants";
 import { useLiveHours } from "@/app/hooks/useLiveHours";
 
 // ── Types ────────────────────────────────────
@@ -24,37 +21,8 @@ export interface DashboardProps {
   cleaningPauseUntil: string | null;
   hasEntries: boolean;
 
-  // Kontrolle
-  offeneKontrolle: {
-    deadline: string;
-    code: string;
-    kommentar: string | null;
-    overdue: boolean;
-    href: string;
-  } | null;
-
-  // Verschluss-Anforderung
-  offeneVerschlussAnf: {
-    endetAt: string | null;
-    nachricht: string | null;
-    overdue: boolean;
-    endetAtLabel: string | null;
-    deviceName: string | null;
-  } | null;
-
-  // Sperrzeit
-  activeSperrzeit: {
-    endetAt: string | null;
-    nachricht: string | null;
-    endetAtLabel: string | null;
-  } | null;
-
-  // Orgasmus-Anforderung
-  offeneOrgasmusAnf: {
-    label: string;
-    nachricht: string | null;
-    windowLabel: string;
-  } | null;
+  // Die Anforderungen mit Frist (Kontrolle, Einschliessen, Orgasmus) stehen NICHT hier, sondern
+  // im eigenen Block `DashboardAlerts` ganz oben auf der Seite — Begründung dort.
 
   // Stats
   tagH: number;
@@ -64,9 +32,6 @@ export interface DashboardProps {
   elapsedTagH: number;
   elapsedWocheH: number;
   elapsedMonatH: number;
-
-  /** Governing timezone of the data owner (sub). Defaults to APP_TZ (Europe/Zurich). */
-  tz?: string;
 }
 
 // ── Helpers ──────────────────────────────────
@@ -87,16 +52,10 @@ function WearPercent({ wornH, elapsedH }: { wornH: number; elapsedH: number }) {
 // ── Component ────────────────────────────────
 export default function DashboardClient(props: DashboardProps) {
   const t = useTranslations("dashboard");
-  const tCommon = useTranslations("common");
-  const locale = useLocale();
   const {
     currentStatus,
     cleaningPauseUntil,
     hasEntries,
-    offeneKontrolle,
-    offeneVerschlussAnf,
-    activeSperrzeit,
-    offeneOrgasmusAnf,
     tagH: baseTagH,
     wocheH: baseWocheH,
     monatH: baseMonatH,
@@ -104,7 +63,6 @@ export default function DashboardClient(props: DashboardProps) {
     elapsedTagH: baseElapsedTagH,
     elapsedWocheH: baseElapsedWocheH,
     elapsedMonatH: baseElapsedMonatH,
-    tz,
   } = props;
 
   const router = useRouter();
@@ -139,33 +97,9 @@ export default function DashboardClient(props: DashboardProps) {
   const elapsedWocheH = useLiveHours(baseElapsedWocheH, serverNow, true);
   const elapsedMonatH = useLiveHours(baseElapsedMonatH, serverNow, true);
 
-  // Lock-Request-Banner — auch im Empty-State sichtbar, sonst sehen frische User
-  // mit einer offenen Anforderung nichts und reagieren nur auf die Mail.
-  const lockRequestBanner = offeneVerschlussAnf ? (
-    <LockRequestBanner
-      variant="large"
-      colorScheme="request"
-      label={t("lockRequested")}
-      nachricht={[offeneVerschlussAnf.deviceName ? t("lockDevicePrefix", { name: offeneVerschlussAnf.deviceName }) : null, offeneVerschlussAnf.nachricht].filter(Boolean).join(" · ") || null}
-      endetAtLabel={offeneVerschlussAnf.endetAtLabel}
-    />
-  ) : null;
-
-  const orgasmusRequestBanner = offeneOrgasmusAnf ? (
-    <LockRequestBanner
-      variant="large"
-      colorScheme="orgasm"
-      label={offeneOrgasmusAnf.label}
-      nachricht={offeneOrgasmusAnf.nachricht}
-      endetAtLabel={offeneOrgasmusAnf.windowLabel}
-    />
-  ) : null;
-
   if (!hasEntries) {
     return (
       <DashboardBlock as="main" className="flex flex-col gap-5">
-        {lockRequestBanner}
-        {orgasmusRequestBanner}
         <EmptyState
           icon={<Lock size={48} />}
           title={t("welcomeTitle")}
@@ -208,26 +142,8 @@ export default function DashboardClient(props: DashboardProps) {
         </div>
       )}
 
-      {/* ── Alert Banners ── */}
-      {offeneKontrolle && (
-        <KontrolleBanner
-          deadline={new Date(offeneKontrolle.deadline)}
-          code={offeneKontrolle.code}
-          kommentar={offeneKontrolle.kommentar}
-          overdue={offeneKontrolle.overdue}
-          variant="large"
-          href={offeneKontrolle.href}
-          openLabel={t("inspectionRequired")}
-          helpHref={inspectionHelpUrl(locale)}
-          tz={tz}
-        />
-      )}
-
-      {lockRequestBanner}
-
-      {orgasmusRequestBanner}
-
-      {/* Sperrzeit-Banner entfernt — wird bereits im Sperrzeit-Footer der LaufendeSessionCard angezeigt */}
+      {/* Anforderungs-Banner: siehe `DashboardAlerts` (eigener Block ganz oben).
+           Sperrzeit-Banner entfernt — steht bereits im Sperrzeit-Footer der LaufendeSessionCard. */}
 
       {/* ── Stats Summary ── */}
       <div className="rounded-xl border border-border bg-surface p-4 sm:p-5">

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -6,7 +6,7 @@ import {
   buildPairs, getOpenPair, interruptionPauseMs, buildKontrolleItems, runningCleaningPauseUntil,
   toDateLocale, calculateWearingHoursByRange,
   getMidnightToday, getWeekStart, getMonthStart,
-  wearingHoursFromPairs, APP_TZ,
+  wearingHoursFromPairs, joinParts, APP_TZ,
   type ReinigungSettings,
 } from "@/lib/utils";
 import { buildWearSessions, wearHourPairsByCategory } from "@/lib/sessionModel";
@@ -20,6 +20,7 @@ import { loadTelemetryKeyProof } from "@/lib/boxKeyProof";
 import { effectiveOrgasmusArten, resolveReasonLabel, resolveOrgasmusArtDisplay } from "@/lib/reasonsService";
 import { getTranslations, getLocale } from "next-intl/server";
 import DashboardClient, { type DashboardProps } from "./DashboardClient";
+import DashboardAlerts, { type DashboardAlertsProps } from "./DashboardAlerts";
 import LaufendeSessionCard from "./LaufendeSessionCard";
 import SessionList from "./SessionList";
 import WearSessionList from "./WearSessionList";
@@ -148,16 +149,12 @@ export default async function DashboardPage() {
     ? `/dashboard/new/pruefung?code=${offeneKontrolle.code}${offeneKontrolle.kommentar ? `&kommentar=${encodeURIComponent(offeneKontrolle.kommentar)}` : ""}`
     : "";
 
-  const anfOverdue = offeneVerschlussAnf ? (offeneVerschlussAnf.endetAt ? offeneVerschlussAnf.endetAt < now : false) : false;
-
   const orgasmusVorgabeLabel = offeneOrgasmusAnf?.vorgegebeneArt
     ? resolveReasonLabel(offeneOrgasmusAnf.vorgegebeneArt, orgasmCfg, "orgasm", tOrgasm)
     : null;
 
-  const clientProps: DashboardProps = {
-    currentStatus,
-    cleaningPauseUntil: cleaningPauseUntil?.toISOString() ?? null,
-    hasEntries: entries.length > 0,
+  const alertProps: DashboardAlertsProps = {
+    tz,
 
     offeneKontrolle: offeneKontrolle ? {
       deadline: offeneKontrolle.deadline.toISOString(),
@@ -168,24 +165,27 @@ export default async function DashboardPage() {
     } : null,
 
     offeneVerschlussAnf: offeneVerschlussAnf ? {
-      endetAt: offeneVerschlussAnf.endetAt?.toISOString() ?? null,
-      nachricht: offeneVerschlussAnf.nachricht,
-      overdue: anfOverdue,
+      nachricht: joinParts(
+        offeneVerschlussAnf.device ? t("lockDevicePrefix", { name: offeneVerschlussAnf.device.name }) : null,
+        offeneVerschlussAnf.nachricht,
+      ),
       endetAtLabel: offeneVerschlussAnf.endetAt ? t("lockUntil", { date: formatDateTime(offeneVerschlussAnf.endetAt, dl, tz) }) : null,
-      deviceName: offeneVerschlussAnf.device?.name ?? null,
-    } : null,
-
-    activeSperrzeit: activeSperrzeit ? {
-      endetAt: activeSperrzeit.endetAt?.toISOString() ?? null,
-      nachricht: activeSperrzeit.nachricht,
-      endetAtLabel: activeSperrzeit.endetAt ? t("openingForbiddenUntil", { date: formatDateTime(activeSperrzeit.endetAt, dl, tz) }) : null,
     } : null,
 
     offeneOrgasmusAnf: offeneOrgasmusAnf ? {
       label: offeneOrgasmusAnf.art === "ANWEISUNG" ? t("orgasmInstructed") : t("orgasmOpportunity"),
-      nachricht: [orgasmusVorgabeLabel ? t("orgasmRequiredArt", { art: orgasmusVorgabeLabel }) : null, offeneOrgasmusAnf.nachricht].filter(Boolean).join(" · ") || null,
+      nachricht: joinParts(
+        orgasmusVorgabeLabel ? t("orgasmRequiredArt", { art: orgasmusVorgabeLabel }) : null,
+        offeneOrgasmusAnf.nachricht,
+      ),
       windowLabel: t("orgasmWindowFromUntil", { from: formatDateTime(offeneOrgasmusAnf.beginntAt, dl, tz), until: formatDateTime(offeneOrgasmusAnf.endetAt, dl, tz) }),
     } : null,
+  };
+
+  const clientProps: DashboardProps = {
+    currentStatus,
+    cleaningPauseUntil: cleaningPauseUntil?.toISOString() ?? null,
+    hasEntries: entries.length > 0,
 
     tagH,
     wocheH,
@@ -205,6 +205,8 @@ export default async function DashboardPage() {
       <DashboardBlock>
         <h1 className="text-xl font-bold text-foreground">{t("userTitle", { name: username })}</h1>
       </DashboardBlock>
+      {/* Anforderungen mit Frist vor allem anderen — auch vor der Box-Karte. */}
+      <DashboardAlerts {...alertProps} />
       {heimdallEnabled() && <BoxStatusCard tz={tz} reinigung={boxReinigung} />}
       {showLaufendeSession && (
         <DashboardBlock>
@@ -266,7 +268,7 @@ export default async function DashboardPage() {
             ),
           }))}
       />
-      <DashboardClient {...clientProps} tz={tz} />
+      <DashboardClient {...clientProps} />
       {pairs.length > 0 && (
         <DashboardBlock>
           <SessionList pairs={pairs} orgasmusEntries={orgasmusEntries} userHasDevices={userHasDevices} tz={tz} orgasmusArtenConfig={userSettings?.orgasmusArtenConfig} oeffnenGruendeConfig={userSettings?.oeffnenGruendeConfig} telemetryKeyProof={telemetryKeyProof} />

--- a/src/data/changelog.json
+++ b/src/data/changelog.json
@@ -1,5 +1,18 @@
 [
   {
+    "version": "4.55.5",
+    "date": "2026-07-28",
+    "changes": [
+      {
+        "type": "ui",
+        "text": {
+          "de": "Offene Anforderungen stehen jetzt zuoberst auf der Übersicht — direkt unter der Begrüssung, noch vor der Box-Karte und der laufenden Session. Bisher sassen sie weiter unten und konnten je nach Ausstattung so weit rutschen, dass man zum Scrollen gezwungen war, um eine laufende Frist überhaupt zu sehen. Neu sieht man eine geforderte Kontrolle auch dann, wenn noch gar keine Einträge erfasst sind.",
+          "en": "Open requests now sit at the very top of the overview — right below the greeting, ahead of the box card and the running session. They used to sit further down and, depending on your setup, could slide far enough that you had to scroll to see a running deadline at all. A requested inspection is now also shown when there are no entries yet."
+        }
+      }
+    ]
+  },
+  {
     "version": "4.55.3",
     "date": "2026-07-28",
     "changes": [

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -102,6 +102,13 @@ export function formatDuration(start: Date, end: Date, locale = "de"): string {
   return parts.join(" ");
 }
 
+/** Fügt die vorhandenen Teile einer einzeiligen Beschriftung mit „ · " zusammen; bleibt nichts
+ *  übrig, `null` — der Aufrufer reicht das Ergebnis meist als optionalen Text weiter, und ein
+ *  leerer String erzeugte dort eine leere Zeile statt gar keiner. */
+export function joinParts(...parts: (string | null | undefined | false)[]): string | null {
+  return parts.filter(Boolean).join(" · ") || null;
+}
+
 /** Maps next-intl locale codes to BCP 47 locale tags for Intl formatting. */
 export function toDateLocale(locale: string): string {
   return locale === "en" ? "en-US" : "de-CH";


### PR DESCRIPTION
Die drei Banner mit Frist (Kontrolle, Einschliessen, Orgasmus) sassen im DashboardClient-Block und damit unterhalb von Box-Karte, Session-Karte, Trage-Sessions, Trainingsvorgaben und "Nicht getragen". Je nach Ausstattung rutschte die Kontrollanforderung damit unter den Fold — eine Frist, die man wegscrollen muss, verfehlt ihren Zweck.

Neu in einer eigenen Server-Komponente DashboardAlerts, gerendert direkt unter der Begruessung und vor der Box-Karte. Sie rendert null, wenn nichts offen ist, und haelt damit die DashboardBlock-Abstandsregel ein.

Nebeneffekt: das Kontroll-Banner erscheint jetzt auch im Empty-State. Bisher sahen nur Einschliess- und Orgasmus-Anforderung dorthin durch; ein frischer Nutzer mit offener Kontrolle sah auf der Uebersicht nichts.

Aufraeumen im selben Zug:
- joinParts() in lib/utils.ts — die dreifach kopierte Idiomatik [a, b].filter(Boolean).join(" · ") || null (page.tsx, DashboardAlerts, BoxStatusCard) hat jetzt eine Quelle.
- Die Zusammensetzung der Anforderungs-Nachricht liegt einheitlich in page.tsx (Datenschicht), nicht mehr halb in der Komponente.
- Tote Props entfernt: DashboardProps.activeSperrzeit (seit dd66ce2 nicht mehr gerendert) samt i18n-Key openingForbiddenUntil, dazu overdue/endetAt der Verschluss-Anforderung, tz und tCommon im DashboardClient.

Version 4.55.5 statt .4: .4 ist auf einem noch nicht gemergten Branch belegt.